### PR TITLE
Chunking requests and fixing tests

### DIFF
--- a/jake/parse/parse.py
+++ b/jake/parse/parse.py
@@ -43,7 +43,6 @@ class Parse(object):
     def reallyGetCondaDependencies(self, run_command_list):
         results = self.runCondaListCommand(run_command_list)
 
-        #self._log.debug("results: " + results)
         length = len(results)
 
         if results[length-1] == 0:
@@ -67,7 +66,7 @@ class Parse(object):
         if len(purls.get_coordinates()) == 0:
             return None
         else:
-            return purls.get_coordinates_as_json()
+            return purls
 
     def parseLineIntoPurl(self, line):
         lineArray = line.split()

--- a/jake/test_ossindex.py
+++ b/jake/test_ossindex.py
@@ -62,3 +62,4 @@ class TestOssIndex(unittest.TestCase):
         self.assertEqual(actual_result[0][0], "pkg:conda/_ipyw_jlab_nb_ext_conf@0.1.0")
         self.assertEqual(actual_result[1][0], "pkg:conda/mistune@0.8.4")
         self.assertEqual(actual_result[2][0], "pkg:conda/yaml@0.1.7")
+        

--- a/jake/test_parse.py
+++ b/jake/test_parse.py
@@ -24,9 +24,9 @@ class TestParse(unittest.TestCase):
 
     def test_callGetDependenciesReturnsPurls(self):
         fn = pathlib.Path(__file__).parent / "condalistoutput.txt"
-        sys.stdin = open(fn, "r")
-        actual = self.func.getDependenciesFromStdin(sys.stdin)
-        output = json.loads(actual)["coordinates"]
+        with open(fn, "r") as stdin:
+            actual = self.func.getDependenciesFromStdin(stdin)
+            output = actual.get_coordinates()
         self.assertEqual(len(output), 262)
         self.assertEqual(output[0], "pkg:conda/_ipyw_jlab_nb_ext_conf@0.1.0")
         self.assertEqual(output[131], "pkg:conda/mkl_fft@1.0.12")


### PR DESCRIPTION
Chunking requests to OSSIndex and fixing tests because of the change

Changes made:
  * Request to OSSIndexs now have no more than 128 purls (limit set by OSSIndex)
  * Tests fixed as a result of above change