### PR TITLE
Make CI scripts fail on any error

### DIFF
--- a/.circleci/ci-run.sh
+++ b/.circleci/ci-run.sh
@@ -5,8 +5,9 @@ source .venv/bin/activate
 pylint jake
 
 LINTER_STATUS=$?
+echo "LINTER_STATUS: $LINTER_STATUS"
 if [ $LINTER_STATUS -ne 0 ]; then
-  echo “failed linter status: $status”
+  echo "failed linter status: $status"
   exit 1
 fi
 

--- a/.circleci/ci-run.sh
+++ b/.circleci/ci-run.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
+set -e
 
 source .venv/bin/activate
 
 pylint jake
-
-LINTER_STATUS=$?
-echo "LINTER_STATUS: $LINTER_STATUS"
-if [ $LINTER_STATUS -ne 0 ]; then
-  echo "failed linter status: $status"
-  exit 1
-fi
 
 python3 -m unittest discover

--- a/.circleci/ci-setup.sh
+++ b/.circleci/ci-setup.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
+set -e
 
 # intended to be run from directory above this one.
 
 # Setup a proper path, I call my virtualenv dir ".venv"
 PATH=$WORKSPACE/.venv/bin:$PATH
-lsb_release -a
 python3 --version
 if [ ! -d ".venv" ]; then
         # use python3 to create .venv


### PR DESCRIPTION
The CI scripts should stop with an error whenever some command fails (rather than plunging ahead after errors).

I'm still trying to figure out why the linter seems to behave differently locally vs ci...

cc @bhamail / @DarthHater
