### PR TITLE
Yaml for Config

### DIFF
--- a/jake/__main__.py
+++ b/jake/__main__.py
@@ -32,7 +32,10 @@ def main():
   """jake entry point"""
   args = __add_parser_args_and_return()
   log = __setup_logger(args.verbose)
-  config = Config()
+  if args.application:
+    config = Config('.iqserver')
+  else:
+    config = Config()
 
   if args.snake:
     __get_config_from_std_in(config)

--- a/jake/__main__.py
+++ b/jake/__main__.py
@@ -142,7 +142,7 @@ def __handle_iq_server(application_id, response, log, config: Config):
 def __get_config_from_std_in(config: Config):
   result = config.get_config_from_std_in()
   if result is False:
-    _exit(OSError)
+    _exit(EX_OSERR)
   else:
     _exit(0)
 

--- a/jake/__main__.py
+++ b/jake/__main__.py
@@ -33,7 +33,7 @@ def main():
   args = __add_parser_args_and_return()
   log = __setup_logger(args.verbose)
   if args.application:
-    config = Config('.iqserver')
+    config = IQConfig()
   else:
     config = Config()
 

--- a/jake/config/config.py
+++ b/jake/config/config.py
@@ -61,8 +61,9 @@ class Config():
     return result
 
   def save_config_to_file(self, fields, config_name):
-    """save stdin to save_location/.oss-index-config or .iq-server-config"""
+    """save stdin to save_location/config_name"""
     try:
+      os.makedirs(os.path.join(self._save_location, config_name), exist_ok=True)
       with open(os.path.join(self._save_location, config_name), "w+") as file:
         yaml.dump(fields, file, default_flow_style=False)
         return True
@@ -71,7 +72,7 @@ class Config():
       return False
 
   def get_config_from_file(self, config_name):
-    """get credentials from save_location/.jake-config"""
+    """get credentials from save_location/config_name"""
     with open(os.path.join(self._save_location, config_name)) as file:
       doc = yaml.full_load(file)
       results = {}

--- a/jake/config/config.py
+++ b/jake/config/config.py
@@ -14,12 +14,13 @@
 # limitations under the License.
 import logging
 import os
+import yaml
 
 from pathlib import Path
 
 class Config():
   """config.py handles getting credentials for OSSIndex or setting them"""
-  def __init__(self, save_location=''):
+  def __init__(self, save_location='', config_foler='.ossindex'):
     self._log = logging.getLogger('jake')
 
     self._config_name = '.oss-index-config'
@@ -31,7 +32,7 @@ class Config():
     if save_location != '':
       self._save_location = save_location
     else:
-      self._save_location = str(Path.home())
+      self._save_location = os.path.join(str(Path.home()), config_foler)
 
     self.__migrate_config_if_at_jake_location()
 
@@ -62,8 +63,7 @@ class Config():
     """save stdin to save_location/.oss-index-config or .iq-server-config"""
     try:
       with open(os.path.join(self._save_location, config_name), "w+") as file:
-        for key, value in fields.items():
-          file.write("{}: {}\n".format(key, value))
+        yaml.dump(fields, file, default_flow_style=False)
         return True
     except FileNotFoundError as exception:
       self._log.error("Uh oh, an error happened: %s", str(exception))
@@ -72,12 +72,10 @@ class Config():
   def get_config_from_file(self, fields, config_name):
     """get credentials from save_location/.jake-config"""
     with open(os.path.join(self._save_location, config_name)) as file:
+      doc = yaml.full_load(file)
       results = {}
-      for line in file.readlines():
-        line_array = line.split(" ")
-        for key in fields:
-          if line_array[0].rstrip(":") == key:
-            results[key] = str(line_array[1]).rstrip()
+      for item, doc in doc.items():
+        results[item] = doc
 
     return results
 

--- a/jake/config/config.py
+++ b/jake/config/config.py
@@ -63,7 +63,7 @@ class Config():
   def save_config_to_file(self, fields, config_name):
     """save stdin to save_location/config_name"""
     try:
-      os.makedirs(os.path.join(self._save_location, config_name), exist_ok=True)
+      os.makedirs(os.path.join(self._save_location), exist_ok=True)
       with open(os.path.join(self._save_location, config_name), "w+") as file:
         yaml.dump(fields, file, default_flow_style=False)
         return True

--- a/jake/config/config.py
+++ b/jake/config/config.py
@@ -21,7 +21,7 @@ import yaml
 
 class Config():
   """config.py handles getting credentials for OSSIndex or setting them"""
-  def __init__(self, save_location='', config_foler='.ossindex'):
+  def __init__(self, config_folder='.ossindex', save_location=''):
     self._log = logging.getLogger('jake')
 
     self._config_name = '.oss-index-config'
@@ -33,7 +33,7 @@ class Config():
     if save_location != '':
       self._save_location = save_location
     else:
-      self._save_location = os.path.join(str(Path.home()), config_foler)
+      self._save_location = os.path.join(str(Path.home()), config_folder)
 
     self.__migrate_config_if_at_jake_location()
 

--- a/jake/config/config.py
+++ b/jake/config/config.py
@@ -55,7 +55,7 @@ class Config():
 
     result = self.save_config_to_file(
         {"Username": self._username,
-         "Password": self._password},
+         "Token": self._password},
         self._config_name)
 
     return result

--- a/jake/config/config.py
+++ b/jake/config/config.py
@@ -14,9 +14,10 @@
 # limitations under the License.
 import logging
 import os
-import yaml
 
 from pathlib import Path
+
+import yaml
 
 class Config():
   """config.py handles getting credentials for OSSIndex or setting them"""
@@ -69,7 +70,7 @@ class Config():
       self._log.error("Uh oh, an error happened: %s", str(exception))
       return False
 
-  def get_config_from_file(self, fields, config_name):
+  def get_config_from_file(self, config_name):
     """get credentials from save_location/.jake-config"""
     with open(os.path.join(self._save_location, config_name)) as file:
       doc = yaml.full_load(file)

--- a/jake/config/iq_config.py
+++ b/jake/config/iq_config.py
@@ -32,7 +32,7 @@ class IQConfig(Config):
 
     result = self.save_config_to_file(
         {"Username": self._username,
-         "Password": self._password,
+         "Token": self._password,
          "IQ-Server-Location": self._iq_server_location},
         self._iq_server_config_name)
 

--- a/jake/config/iq_config.py
+++ b/jake/config/iq_config.py
@@ -33,7 +33,7 @@ class IQConfig(Config):
     result = self.save_config_to_file(
         {"Username": self._username,
          "Token": self._password,
-         "IQ-Server-Location": self._iq_server_location},
+         "Server": self._iq_server_location},
         self._iq_server_config_name)
 
     return result

--- a/jake/config/iq_config.py
+++ b/jake/config/iq_config.py
@@ -17,7 +17,7 @@ from jake.config.config import Config
 class IQConfig(Config):
   """does IQ specific config setting and retrieval"""
   def __init__(self, save_location=''):
-    super().__init__(save_location, config_foler='.iqserver')
+    super().__init__('.iqserver', save_location)
     self._iq_server_config_name = '.iq-server-config'
     self._iq_server_location = ''
 

--- a/jake/config/iq_config.py
+++ b/jake/config/iq_config.py
@@ -17,7 +17,7 @@ from jake.config.config import Config
 class IQConfig(Config):
   """does IQ specific config setting and retrieval"""
   def __init__(self, save_location=''):
-    super().__init__(save_location)
+    super().__init__(save_location, config_foler='.iqserver')
     self._iq_server_config_name = '.iq-server-config'
     self._iq_server_location = ''
 
@@ -34,6 +34,6 @@ class IQConfig(Config):
         {"Username": self._username,
          "Password": self._password,
          "IQ-Server-Location": self._iq_server_location},
-        ".iq-server-config")
+        self._iq_server_config_name)
 
     return result

--- a/jake/cyclonedx/v1_1/generator.py
+++ b/jake/cyclonedx/v1_1/generator.py
@@ -67,6 +67,7 @@ class CycloneDx11Generator():
             component.get_coordinates(),
             vulnerabilities,
             node)
+        self.validate_xml(vulnerabilities)
     self.__xml.append(components)
 
   @staticmethod

--- a/jake/iq/iq.py
+++ b/jake/iq/iq.py
@@ -39,8 +39,8 @@ class IQ():
     results = config.get_config_from_file(".iq-server-config")
 
     self._user = results['Username']
-    self._password = results['Password']
-    self._iq_server_base_url = results['IQ-Server-Location']
+    self._password = results['Token']
+    self._iq_server_base_url = results['Server']
 
   def get_url(self):
     """gets url to use for IQ Server request"""

--- a/jake/iq/iq.py
+++ b/jake/iq/iq.py
@@ -36,11 +36,7 @@ class IQ():
     self._report_url = ''
     self._policy_action = None
     config = IQConfig()
-    results = config.get_config_from_file(
-        {"Username",
-         "Password",
-         "IQ-Server-Location"},
-        ".iq-server-config")
+    results = config.get_config_from_file(".iq-server-config")
 
     self._user = results['Username']
     self._password = results['Password']

--- a/jake/ossindex/ossindex.py
+++ b/jake/ossindex/ossindex.py
@@ -104,7 +104,7 @@ class OssIndex():
         response = requests.post(self.get_url(),
                                  data=json.dumps(data),
                                  headers=self.get_headers(),
-                                 auth=(auth["Username"], auth["Password"]))
+                                 auth=(auth["Username"], auth["Token"]))
       if response.status_code == 200:
         self._log.debug(response.headers)
         first_results = json.loads(response.text, cls=ResultsDecoder)

--- a/jake/ossindex/ossindex.py
+++ b/jake/ossindex/ossindex.py
@@ -99,8 +99,6 @@ class OssIndex():
             data), headers=self.get_headers())
       else:
         auth = config_file.get_config_from_file(
-            {"Username",
-             "Password"},
             ".oss-index-config")
 
         response = requests.post(self.get_url(),

--- a/jake/test/test_config.py
+++ b/jake/test/test_config.py
@@ -35,7 +35,7 @@ class TestConfig(unittest.TestCase):
         {"Username": "test@me.com", "Password": "password"},
         ".oss-index-config")
 
-    results = self.func.get_config_from_file({"Username", "Password"}, ".oss-index-config")
+    results = self.func.get_config_from_file(".oss-index-config")
     self.assertEqual(results["Username"], "test@me.com")
     self.assertEqual(results["Password"], "password")
 

--- a/jake/test/test_config.py
+++ b/jake/test/test_config.py
@@ -25,23 +25,23 @@ class TestConfig(unittest.TestCase):
   def test_config_object_saves_config_file(self):
     """test_config_object_saves_config_file ensures config objs are being written to file"""
     result = self.func.save_config_to_file(
-        {"Username": "test@me.com", "Password": "password"},
+        {"Username": "test@me.com", "Token": "password"},
         ".oss-index-config")
     self.assertEqual(result, True)
 
   def test_get_config_from_file(self):
     """test_config_object_saves_config_file ensures config objs are being written to file"""
     self.func.save_config_to_file(
-        {"Username": "test@me.com", "Password": "password"},
+        {"Username": "test@me.com", "Token": "password"},
         ".oss-index-config")
 
     results = self.func.get_config_from_file(".oss-index-config")
     self.assertEqual(results["Username"], "test@me.com")
-    self.assertEqual(results["Password"], "password")
+    self.assertEqual(results["Token"], "password")
 
   def test_return_true_when_config_exists(self):
     """test_config_object_saves_config_file ensures config objs are being written to file"""
     self.func.save_config_to_file(
-        {"Username": "test@me.com", "Password": "password"},
+        {"Username": "test@me.com", "Token": "password"},
         ".oss-index-config")
     self.assertEqual(self.func.check_if_config_exists(), True)

--- a/jake/test/test_iq_config.py
+++ b/jake/test/test_iq_config.py
@@ -36,10 +36,7 @@ http://localhost:8070/"""
     result = self.func.get_config_from_std_in()
     self.assertEqual(result, True)
     # reread stored config
-    results = self.func.get_config_from_file({"Username",
-                                              "Password",
-                                              "IQ-Server-Location"},
-                                             ".iq-server-config")
+    results = self.func.get_config_from_file(".iq-server-config")
     self.assertEqual(results["Username"], "test@me.com")
     self.assertEqual(results["Password"], "password")
     self.assertEqual(results["IQ-Server-Location"], "http://localhost:8070")

--- a/jake/test/test_iq_config.py
+++ b/jake/test/test_iq_config.py
@@ -38,5 +38,5 @@ http://localhost:8070/"""
     # reread stored config
     results = self.func.get_config_from_file(".iq-server-config")
     self.assertEqual(results["Username"], "test@me.com")
-    self.assertEqual(results["Password"], "password")
-    self.assertEqual(results["IQ-Server-Location"], "http://localhost:8070")
+    self.assertEqual(results["Token"], "password")
+    self.assertEqual(results["Server"], "http://localhost:8070")

--- a/jake/types/results_decoder.py
+++ b/jake/types/results_decoder.py
@@ -42,8 +42,8 @@ class ResultsDecoder(json.JSONDecoder):
     vulnerability.set_id(dictionary.get("id"))
     vulnerability.set_title(dictionary.get("title"))
     vulnerability.set_description(dictionary.get("description"))
-    vulnerability.set_cvss_score(dictionary.get("cvssScore"))
-    vulnerability.set_cvss_vector(dictionary.get('cvssVector'))
+    vulnerability.set_cvss_score(dictionary.get("cvss_score"))
+    vulnerability.set_cvss_vector(dictionary.get('cvss_vector'))
     vulnerability.set_cve(dictionary.get("cve"))
     vulnerability.set_reference(dictionary.get("reference"))
 

--- a/jake/types/results_decoder.py
+++ b/jake/types/results_decoder.py
@@ -42,8 +42,8 @@ class ResultsDecoder(json.JSONDecoder):
     vulnerability.set_id(dictionary.get("id"))
     vulnerability.set_title(dictionary.get("title"))
     vulnerability.set_description(dictionary.get("description"))
-    vulnerability.set_cvss_score(dictionary.get("cvss_score"))
-    vulnerability.set_cvss_vector(dictionary.get('cvss_vector'))
+    vulnerability.set_cvss_score(dictionary.get("cvssScore"))
+    vulnerability.set_cvss_vector(dictionary.get('cvssVector'))
     vulnerability.set_cve(dictionary.get("cve"))
     vulnerability.set_reference(dictionary.get("reference"))
 

--- a/jake/types/vulnerabilities.py
+++ b/jake/types/vulnerabilities.py
@@ -22,8 +22,8 @@ class Vulnerabilities():
     self.id = ""
     self.title = ""
     self.description = ""
-    self.cvss_score = ""
-    self.cvss_vector = None
+    self.cvssScore = ""
+    self.cvssVector = None
     self.cve = ""
     self.reference = ""
 
@@ -51,22 +51,22 @@ class Vulnerabilities():
     """gets description for Vulnerabilities object"""
     return self.description
 
-  def set_cvss_score(self, cvss_score):
+  def set_cvss_score(self, cvssScore):
     """sets cvss_score for Vulnerabilities object"""
-    self.cvss_score = cvss_score
+    self.cvssScore = cvssScore
 
   def get_cvss_score(self):
     """gets cvss_score for Vulnerabilities object"""
-    return self.cvss_score
+    return self.cvssScore
 
-  def set_cvss_vector(self, cvss_vector):
+  def set_cvss_vector(self, cvssVector):
     """sets cvss_vector Vulnerabilities object if it exists"""
-    if cvss_vector is not None:
-      self.cvss_vector = cvss_vector
+    if cvssVector is not None:
+      self.cvssVector = cvssVector
 
   def get_cvss_vector(self):
     """gets cvss_vector for Vulnerabilities object"""
-    return self.cvss_vector
+    return self.cvssVector
 
   def set_cve(self, cve):
     """sets cve for Vulnerabilities object"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ mccabe==0.6.1
 polling==0.3.1
 pylint==2.4.4
 python-dateutil==2.8.1
+PyYAML==5.2
 requests==2.22.0
 six==1.13.0
 tinydb==3.15.1


### PR DESCRIPTION
Because who doesn't like yaml?!?!

Seriously though we are starting to save OSS Index config in a few tools, so why not use yaml, and a common location, so they can all pick it up. 

This pull request makes the following changes:
* Adds PyYAML
* Implements yaml load and dump in base config class
* Also moves config by default to it's own `.ossindex` folder

cc @bhamail / @DarthHater / @allenhsieh 
