### PR TITLE
Sbom mkdir if it doesn't exist and error handling

### DIFF
--- a/.circleci/ci-publish.sh
+++ b/.circleci/ci-publish.sh
@@ -15,4 +15,4 @@ git config user.name "$GITHUB_USERNAME"
 
 git config user.email "$GITHUB_EMAIL"
 
-semantic-release publish --patch
+semantic-release publish --minor

--- a/jake/__main__.py
+++ b/jake/__main__.py
@@ -19,7 +19,7 @@
 import sys
 import io
 import logging
-from os import _exit, EX_OSERR, path, mkdir
+from os import _exit, EX_OSERR, path, mkdir, makedirs, PermissionError
 from pathlib import Path
 
 import click
@@ -173,6 +173,7 @@ def sbom(verbose, quiet, conda, targets, output):
   if not output:
     print(sbom_xml)
   else:
+    makedirs(path.dirname(output), exist_ok=True)
     with open(output, 'w') as bom_file:
       print(sbom_xml, file=bom_file)
   _exit(0)

--- a/jake/__main__.py
+++ b/jake/__main__.py
@@ -19,7 +19,7 @@
 import sys
 import io
 import logging
-from os import _exit, EX_OSERR, path, mkdir, makedirs
+from os import _exit, path, mkdir, makedirs
 from errno import EACCES, EPERM
 from pathlib import Path
 
@@ -141,7 +141,7 @@ def config(conf):
   # exits 0 if config was set, with non-zero from os if it failed
   result = cli_config.get_config_from_std_in()
   if result is False:
-    _exit(EX_OSERR)
+    _exit(1)
   else:
     _exit(0)
 
@@ -221,7 +221,7 @@ def ddt(verbose, quiet, conda, targets):
       click.echo(
           "Something went horribly wrong, there is no response from OSS Index",
           "please rerun with -VV to see what happened")
-      _exit(EX_OSERR)
+      _exit(1)
     spinner.ok("🐍 ")
 
   with yaspin(text="Loading", color="yellow") as spinner:

--- a/jake/__main__.py
+++ b/jake/__main__.py
@@ -164,7 +164,7 @@ def sbom(verbose, quiet, conda, targets, output):
   if not verbose:
     quiet = __toggle_stdout(on=False)
   __banner(quiet)
-  logger = __setup_logger(verbose)
+  __setup_logger(verbose)
   __check_stdin(conda)
 
   sbom_xml = __sbom_control_flow(conda, targets).decode('utf-8')

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup, find_packages
 
 from jake._version import __version__
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf8") as fh:
   LONG_DESCRIPTION = fh.read()
 
 with open('requirements.txt') as requirements:


### PR DESCRIPTION
Creates the directory of the path that gets passed in for the sbom output if it doesn't exist

Also handled permission errors for when the python shell can't create it

Should work in windows since it uses os.path for everything but still need to test

* Fixes #23 

cc @bhamail / @DarthHater / @maurycupitt 
