### PR TITLE
Added support for Windows OS

### DIFF
--- a/jake/__main__.py
+++ b/jake/__main__.py
@@ -19,12 +19,8 @@
 import sys
 import io
 import logging
-import platform
-if platform.system() != 'Windows':
-  from os import _exit, EX_OSERR, path, mkdir
-else:
-  from os import _exit, path, mkdir
-  EX_OSERR = 1
+from os import _exit, path, mkdir
+
 from pathlib import Path
 
 import click
@@ -145,7 +141,7 @@ def config(conf):
   # exits 0 if config was set, with non-zero from os if it failed
   result = cli_config.get_config_from_std_in()
   if result is False:
-    _exit(EX_OSERR)
+    _exit(1)
   else:
     _exit(0)
 
@@ -212,7 +208,7 @@ def ddt(verbose, quiet, conda, targets):
       click.echo(
           "Something went horribly wrong, there is no response from OSS Index",
           "please rerun with -VV to see what happened")
-      _exit(EX_OSERR)
+      _exit(1)
     spinner.ok("🐍 ")
 
   with yaspin(text="Loading", color="yellow") as spinner:

--- a/jake/__main__.py
+++ b/jake/__main__.py
@@ -19,7 +19,12 @@
 import sys
 import io
 import logging
-from os import _exit, EX_OSERR, path, mkdir
+import platform
+if platform.system() != 'Windows':
+  from os import _exit, EX_OSERR, path, mkdir
+else:
+  from os import _exit, path, mkdir
+  EX_OSERR = 1
 from pathlib import Path
 
 import click

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup, find_packages
 
 from jake._version import __version__
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf8") as fh:
   LONG_DESCRIPTION = fh.read()
 
 with open('requirements.txt') as requirements:


### PR DESCRIPTION
Provides support for this to run on Windows. 

This pull request makes the following changes:
* Checks platform before importing os.EX_OSERR. If the platform is Windows, it will set EX_OSERR to 1
* Explicitly sets file encoding in setup.py in default encoding is not utf8

It relates to the following issue #s:
* Fixes #25

cc @bhamail / @DarthHater
