### PR TITLE
Group good 'n' bad vulnerabilities and output them in tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,28 @@
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+
+# Auto-generated tag files
+tags
+
+# Persistent undo
+[._]*.un~
+
+# Coc configuration directory
+.vim
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/jake/audit/audit.py
+++ b/jake/audit/audit.py
@@ -89,13 +89,14 @@ class Audit:
     table_data = [
             ["ID", vulnerability.get_id()],
             ["Title", vulnerability.get_title()],
-            ["Description", vulnerability.get_description()],
+            ["Description", '\n'.join(wrap(vulnerability.get_description(), 100))],
             ["CVSS Score", f"{vulnerability.get_cvss_score()} - {cls.get_cvss_severity(cvss_score)}"],
             ]
     if vulnerability.get_cvss_vector():
         table_data.append(
                 ["CVSS Vector", vulnerability.get_cvss_vector()]
                 )
+
     table_data.extend(
             [
                 ["CVE", vulnerability.get_cve()],
@@ -104,6 +105,8 @@ class Audit:
             )
     
     table_instance = DoubleTable(table_data)
+    table_instance.inner_heading_row_border = False
+    table_instance.inner_row_border = True
     cls.do_print(table_instance.table, cvss_score)
 
     print("----------------------------------------------------")

--- a/jake/audit/audit.py
+++ b/jake/audit/audit.py
@@ -41,15 +41,17 @@ class Audit:
     pkg_num = 0
     good = [x for x in results if len(x.get_vulnerabilities()) == 0]
     bad = [x for x in results if len(x.get_vulnerabilities()) > 0]
-    print() 
+
+    print()
     print("Non-Vulnerable Dependencies")
-    print() 
+    print()
     for coordinate in good:
       pkg_num += 1
       total_vulns += self.print_result(coordinate, pkg_num, len(results))
-    print() 
+
+    print()
     print("Vulnerable Dependencies")
-    print() 
+    print()
     for coordinate in bad:
       pkg_num += 1
       total_vulns += self.print_result(coordinate, pkg_num, len(results))

--- a/jake/audit/audit.py
+++ b/jake/audit/audit.py
@@ -16,9 +16,9 @@
 import logging
 
 from typing import List
+from textwrap import wrap
 from colorama import Fore
 from terminaltables import DoubleTable
-from textwrap import wrap
 
 from ..types.coordinateresults import CoordinateResults
 from ..types.vulnerabilities import Vulnerabilities
@@ -85,25 +85,23 @@ class Audit:
     print_vulnerability takes a vulnerability, and well, it prints it
     """
     cvss_score = vulnerability.get_cvss_score()
-    
     table_data = [
-            ["ID", vulnerability.get_id()],
-            ["Title", vulnerability.get_title()],
-            ["Description", '\n'.join(wrap(vulnerability.get_description(), 100))],
-            ["CVSS Score", f"{vulnerability.get_cvss_score()} - {cls.get_cvss_severity(cvss_score)}"],
-            ]
+        ["ID", vulnerability.get_id()],
+        ["Title", vulnerability.get_title()],
+        ["Description", '\n'.join(wrap(vulnerability.get_description(), 100))],
+        ["CVSS Score", f"{vulnerability.get_cvss_score()} - {cls.get_cvss_severity(cvss_score)}"],
+        ]
     if vulnerability.get_cvss_vector():
-        table_data.append(
-                ["CVSS Vector", vulnerability.get_cvss_vector()]
-                )
+      table_data.append(
+          ["CVSS Vector", vulnerability.get_cvss_vector()]
+          )
 
     table_data.extend(
-            [
-                ["CVE", vulnerability.get_cve()],
-                ["Reference", vulnerability.get_reference()]
-            ]
-            )
-    
+        [
+            ["CVE", vulnerability.get_cve()],
+            ["Reference", vulnerability.get_reference()]
+        ]
+        )
     table_instance = DoubleTable(table_data)
     table_instance.inner_heading_row_border = False
     table_instance.inner_row_border = True

--- a/jake/audit/audit.py
+++ b/jake/audit/audit.py
@@ -39,8 +39,18 @@ class Audit:
 
     total_vulns = 0
     pkg_num = 0
-
-    for coordinate in results:
+    good = [x for x in results if len(x.get_vulnerabilities()) == 0]
+    bad = [x for x in results if len(x.get_vulnerabilities()) > 0]
+    print() 
+    print("Non-Vulnerable Dependencies")
+    print() 
+    for coordinate in good:
+      pkg_num += 1
+      total_vulns += self.print_result(coordinate, pkg_num, len(results))
+    print() 
+    print("Vulnerable Dependencies")
+    print() 
+    for coordinate in bad:
       pkg_num += 1
       total_vulns += self.print_result(coordinate, pkg_num, len(results))
 
@@ -71,7 +81,10 @@ class Audit:
         )
       return len(coordinate.get_vulnerabilities())
     self.do_print(
-        f"[{number}/{length}] - {coordinate.get_coordinates()} [VULNERABLE] "
+        f"[{number}/{length}] - {coordinate.get_coordinates()} [VULNERABLE]",
+        coordinate.get_max_cvss_score(),
+    )
+    self.do_print(
         f"{len(coordinate.get_vulnerabilities())} known vulnerabilities for this version",
         coordinate.get_max_cvss_score(),
     )

--- a/jake/audit/audit.py
+++ b/jake/audit/audit.py
@@ -17,6 +17,7 @@ import logging
 
 from typing import List
 from colorama import Fore
+from terminaltables import DoubleTable
 
 from ..types.coordinateresults import CoordinateResults
 from ..types.vulnerabilities import Vulnerabilities
@@ -40,6 +41,17 @@ class Audit():
     for coordinate in results:
       pkg_num += 1
       total_vulns += self.print_result(coordinate, pkg_num, len(results))
+
+    table_data = [
+        ["Audited Dependencies", len(results)],
+        ["Vulnerablities Found", total_vulns],
+    ]
+
+    table_instance = DoubleTable(table_data, "Summary")
+
+    print()
+
+    print(table_instance.table)
 
     return total_vulns
 

--- a/jake/audit/audit.py
+++ b/jake/audit/audit.py
@@ -70,7 +70,7 @@ class Audit:
         )
       return len(coordinate.get_vulnerabilities())
     self.do_print(
-        f"[{number}/{length}] - {coordinate.get_coordinates()} [VULNERABLE]"
+        f"[{number}/{length}] - {coordinate.get_coordinates()} [VULNERABLE] "
         f"{len(coordinate.get_vulnerabilities())} known vulnerabilities for this version",
         coordinate.get_max_cvss_score(),
     )

--- a/jake/audit/audit.py
+++ b/jake/audit/audit.py
@@ -42,19 +42,22 @@ class Audit:
     good = [x for x in results if len(x.get_vulnerabilities()) == 0]
     bad = [x for x in results if len(x.get_vulnerabilities()) > 0]
 
-    print()
-    print("Non-Vulnerable Dependencies")
-    print()
-    for coordinate in good:
-      pkg_num += 1
-      total_vulns += self.print_result(coordinate, pkg_num, len(results))
+    if len(good) != 0:
+      print()
+      print("Non-Vulnerable Dependencies")
+      print()
+      for coordinate in good:
+        pkg_num += 1
+        total_vulns += self.print_result(coordinate, pkg_num, len(results))
 
-    print()
-    print("Vulnerable Dependencies")
-    print()
-    for coordinate in bad:
-      pkg_num += 1
-      total_vulns += self.print_result(coordinate, pkg_num, len(results))
+    if len(bad) != 0:
+      print()
+      print("Vulnerable Dependencies")
+      print()
+
+      for coordinate in bad:
+        pkg_num += 1
+        total_vulns += self.print_result(coordinate, pkg_num, len(results))
 
     table_data = [
         ["Audited Dependencies", len(results)],

--- a/jake/audit/audit.py
+++ b/jake/audit/audit.py
@@ -84,19 +84,39 @@ class Audit:
     print_vulnerability takes a vulnerability, and well, it prints it
     """
     cvss_score = vulnerability.get_cvss_score()
-    cls.do_print(f"ID: {vulnerability.get_id()}", cvss_score)
-    cls.do_print(f"Title: {vulnerability.get_title()}", cvss_score)
-    cls.do_print(f"Description: {vulnerability.get_description()}", cvss_score)
-    cls.do_print(
-        f"CVSS Score: {vulnerability.get_cvss_score()} - {cls.get_cvss_severity(cvss_score)}",
-        cvss_score,
-    )
-    if vulnerability.get_cvss_vector() is not None:
-      cls.do_print(
-          f"CVSS Vector: {vulnerability.get_cvss_vector()}", cvss_score
-      )
-    cls.do_print(f"CVE: {vulnerability.get_cve()}", cvss_score)
-    cls.do_print(f"Reference: {vulnerability.get_reference()}", cvss_score)
+    table_data = [
+            ["ID", vulnerability.get_id()],
+            ["Title", vulnerability.get_title()],
+            ["Description", vulnerability.get_description()],
+            ["CVSS Score", f"{vulnerability.get_cvss_score()} - {cls.get_cvss_severity(cvss_score)}"],
+            ]
+
+    # cls.do_print(f"ID: {vulnerability.get_id()}", cvss_score)
+    # cls.do_print(f"Title: {vulnerability.get_title()}", cvss_score)
+    # cls.do_print(f"Description: {vulnerability.get_description()}", cvss_score)
+    # cls.do_print(
+        # f"CVSS Score: {vulnerability.get_cvss_score()} - {cls.get_cvss_severity(cvss_score)}",
+        # cvss_score,
+    # )
+    if vulnerability.get_cvss_vector():
+        table_data.append(
+                ["CVSS Vector", vulnerability.get_cvss_vector]
+                )
+      # cls.do_print(
+          # f"CVSS Vector: {vulnerability.get_cvss_vector()}", cvss_score
+      # )
+    table_data.extend(
+            [
+                ["CVE", vulnerability.get_cve],
+                ["Reference", vulnerability.get_reference]
+            ]
+            )
+    # cls.do_print(f"CVE: {vulnerability.get_cve()}", cvss_score)
+    # cls.do_print(f"Reference: {vulnerability.get_reference()}", cvss_score)
+    
+    table_instance = DoubleTable(table_data)
+    cls.do_print(table_instance.table, cvss_score)
+
     print("----------------------------------------------------")
 
   @classmethod

--- a/jake/audit/audit.py
+++ b/jake/audit/audit.py
@@ -70,7 +70,7 @@ class Audit:
         )
       return len(coordinate.get_vulnerabilities())
     self.do_print(
-        f"[{number}/{length}] - {coordinate.get_coordinates()} [VULNERABLE]" 
+        f"[{number}/{length}] - {coordinate.get_coordinates()} [VULNERABLE]"
         f"{len(coordinate.get_vulnerabilities())} known vulnerabilities for this version",
         coordinate.get_max_cvss_score(),
     )

--- a/jake/audit/audit.py
+++ b/jake/audit/audit.py
@@ -18,6 +18,7 @@ import logging
 from typing import List
 from colorama import Fore
 from terminaltables import DoubleTable
+from textwrap import wrap
 
 from ..types.coordinateresults import CoordinateResults
 from ..types.vulnerabilities import Vulnerabilities
@@ -84,35 +85,23 @@ class Audit:
     print_vulnerability takes a vulnerability, and well, it prints it
     """
     cvss_score = vulnerability.get_cvss_score()
+    
     table_data = [
             ["ID", vulnerability.get_id()],
             ["Title", vulnerability.get_title()],
             ["Description", vulnerability.get_description()],
             ["CVSS Score", f"{vulnerability.get_cvss_score()} - {cls.get_cvss_severity(cvss_score)}"],
             ]
-
-    # cls.do_print(f"ID: {vulnerability.get_id()}", cvss_score)
-    # cls.do_print(f"Title: {vulnerability.get_title()}", cvss_score)
-    # cls.do_print(f"Description: {vulnerability.get_description()}", cvss_score)
-    # cls.do_print(
-        # f"CVSS Score: {vulnerability.get_cvss_score()} - {cls.get_cvss_severity(cvss_score)}",
-        # cvss_score,
-    # )
     if vulnerability.get_cvss_vector():
         table_data.append(
-                ["CVSS Vector", vulnerability.get_cvss_vector]
+                ["CVSS Vector", vulnerability.get_cvss_vector()]
                 )
-      # cls.do_print(
-          # f"CVSS Vector: {vulnerability.get_cvss_vector()}", cvss_score
-      # )
     table_data.extend(
             [
-                ["CVE", vulnerability.get_cve],
-                ["Reference", vulnerability.get_reference]
+                ["CVE", vulnerability.get_cve()],
+                ["Reference", vulnerability.get_reference()]
             ]
             )
-    # cls.do_print(f"CVE: {vulnerability.get_cve()}", cvss_score)
-    # cls.do_print(f"Reference: {vulnerability.get_reference()}", cvss_score)
     
     table_instance = DoubleTable(table_data)
     cls.do_print(table_instance.table, cvss_score)

--- a/jake/audit/audit.py
+++ b/jake/audit/audit.py
@@ -22,111 +22,112 @@ from terminaltables import DoubleTable
 from ..types.coordinateresults import CoordinateResults
 from ..types.vulnerabilities import Vulnerabilities
 
-class Audit():
-  """ Audit does the business, it prints results from OSS Index to the standard out """
-  def __init__(self, quiet=False):
-    self._log = logging.getLogger('jake')
-    self._quiet = quiet
 
-  def audit_results(self, results: List[CoordinateResults]):
-    """
+class Audit:
+    """ Audit does the business, it prints results from OSS Index to the standard out """
+
+    def __init__(self, quiet=False):
+        self._log = logging.getLogger("jake")
+        self._quiet = quiet
+
+    def audit_results(self, results: List[CoordinateResults]):
+        """
     audit_results is the ingest point for the results from OSS Index,
     and handles control flow
     """
-    self._log.debug("Results recieved, %s total results", len(results))
+        self._log.debug("Results received, %s total results", len(results))
 
-    total_vulns = 0
-    pkg_num = 0
+        total_vulns = 0
+        pkg_num = 0
 
-    for coordinate in results:
-      pkg_num += 1
-      total_vulns += self.print_result(coordinate, pkg_num, len(results))
+        for coordinate in results:
+            pkg_num += 1
+            total_vulns += self.print_result(coordinate, pkg_num, len(results))
 
-    table_data = [
-        ["Audited Dependencies", len(results)],
-        ["Vulnerablities Found", total_vulns],
-    ]
+        table_data = [
+            ["Audited Dependencies", len(results)],
+            ["Vulnerablities Found", total_vulns],
+        ]
 
-    table_instance = DoubleTable(table_data, "Summary")
+        table_instance = DoubleTable(table_data, "Summary")
 
-    print()
+        print()
 
-    print(table_instance.table)
+        print(table_instance.table)
 
-    return total_vulns
+        return total_vulns
 
-  def print_result(self, coordinate: CoordinateResults, number, length):
-    """
+    def print_result(self, coordinate: CoordinateResults, number, length):
+        """
     print_results takes a coordinate, the index of the coordinate in a list,
     and the length, and handles printing it in different formats if a
     vulnerability exists
     """
-    if len(coordinate.get_vulnerabilities()) == 0:
-      if not self._quiet:
-        self.do_print("[{}/{}] - {} - no known vulnerabilities for this version"
-                      .format(
-                          number,
-                          length,
-                          coordinate.get_coordinates()), 0)
-      return len(coordinate.get_vulnerabilities())
+        if len(coordinate.get_vulnerabilities()) == 0:
+            if not self._quiet:
+                self.do_print(
+                    f"[{number}/{length}] - {coordinate.get_coordinates()} - no known vulnerabilities for this version",
+                    0
+                )
+            return len(coordinate.get_vulnerabilities())
+        self.do_print(
+            f"[{number}/{length}] - {coordinate.get_coordinates()} [VULNERABLE] {len(coordinate.get_vulnerabilities())} known vulnerabilities for this version",
+            coordinate.get_max_cvss_score(),
+        )
+        for vulnerability in coordinate.get_vulnerabilities():
+            self.print_vulnerability(vulnerability)
+        return len(coordinate.get_vulnerabilities())
 
-    self.do_print(("[{}/{}] - {} [VULNERABLE] {} known vulnerabilities for"
-                   "this version")
-                  .format(
-                      number,
-                      length,
-                      coordinate.get_coordinates(),
-                      len(coordinate.get_vulnerabilities())), coordinate.get_max_cvss_score())
-    for vulnerability in coordinate.get_vulnerabilities():
-      self.print_vulnerability(vulnerability)
-    return len(coordinate.get_vulnerabilities())
-
-  @classmethod
-  def print_vulnerability(cls, vulnerability: Vulnerabilities):
-    """
+    @classmethod
+    def print_vulnerability(cls, vulnerability: Vulnerabilities):
+        """
     print_vulnerability takes a vulnerability, and well, it prints it
     """
-    cvss_score = vulnerability.get_cvss_score()
-    cls.do_print("ID: {}".format(vulnerability.get_id()), cvss_score)
-    cls.do_print("Title: {}".format(vulnerability.get_title()), cvss_score)
-    cls.do_print("Description: {}".format(vulnerability.get_description()), cvss_score)
-    cls.do_print("CVSS Score: {} - {}".format(vulnerability.get_cvss_score(),
-                                              cls.get_cvss_severity(cvss_score)), cvss_score)
-    if vulnerability.get_cvss_vector() is not None:
-      cls.do_print("CVSS Vector: {}".format(vulnerability.get_cvss_vector()), cvss_score)
-    cls.do_print("CVE: {}".format(vulnerability.get_cve()), cvss_score)
-    cls.do_print("Reference: {}".format(vulnerability.get_reference()), cvss_score)
-    print("----------------------------------------------------")
+        cvss_score = vulnerability.get_cvss_score()
+        cls.do_print(f"ID: {vulnerability.get_id()}", cvss_score)
+        cls.do_print(f"Title: {vulnerability.get_title()}", cvss_score)
+        cls.do_print(f"Description: {vulnerability.get_description()}", cvss_score)
+        cls.do_print(
+            f"CVSS Score: {vulnerability.get_cvss_score()} - {cls.get_cvss_severity(cvss_score)}",
+            cvss_score,
+        )
+        if vulnerability.get_cvss_vector() is not None:
+            cls.do_print(
+                f"CVSS Vector: {vulnerability.get_cvss_vector()}", cvss_score
+            )
+        cls.do_print(f"CVE: {vulnerability.get_cve()}", cvss_score)
+        cls.do_print(f"Reference: {vulnerability.get_reference()}", cvss_score)
+        print("----------------------------------------------------")
 
-  @classmethod
-  def do_print(cls, text, cvss_score):
-    """
+    @classmethod
+    def do_print(cls, text, cvss_score):
+        """
     do_print takes text, and a cvss_score and prints it in a different text depending on
     the score
     """
-    if cvss_score == 0:
-      print(Fore.GREEN + text + Fore.RESET)
-    elif 0 < cvss_score < 4:
-      print(Fore.CYAN + text + Fore.RESET)
-    elif 4 <= cvss_score < 7:
-      print(Fore.LIGHTYELLOW_EX + text  + Fore.RESET)
-    elif 7 <= cvss_score < 9:
-      print(Fore.YELLOW + text + Fore.RESET)
-    else:
-      print(Fore.RED + text + Fore.RESET)
+        if cvss_score == 0:
+            print(Fore.GREEN + text + Fore.RESET)
+        elif 0 < cvss_score < 4:
+            print(Fore.CYAN + text + Fore.RESET)
+        elif 4 <= cvss_score < 7:
+            print(Fore.LIGHTYELLOW_EX + text + Fore.RESET)
+        elif 7 <= cvss_score < 9:
+            print(Fore.YELLOW + text + Fore.RESET)
+        else:
+            print(Fore.RED + text + Fore.RESET)
 
-  @classmethod
-  def get_cvss_severity(cls, cvss_score):
-    """
+    @classmethod
+    def get_cvss_severity(cls, cvss_score):
+        """
     get_cvss_severity takes a cvss_score and returns a human readable severity for it
     """
-    if cvss_score == 0:
-      return "None"
-    elif 0 < cvss_score < 4:
-      return "Low"
-    elif 4 <= cvss_score < 7:
-      return "Medium"
-    elif 7 <= cvss_score < 9:
-      return "High"
-    else:
-      return "Critical"
+        if cvss_score == 0:
+            return "None"
+        elif 0 < cvss_score < 4:
+            return "Low"
+        elif 4 <= cvss_score < 7:
+            return "Medium"
+        elif 7 <= cvss_score < 9:
+            return "High"
+        else:
+            return "Critical"

--- a/jake/audit/audit.py
+++ b/jake/audit/audit.py
@@ -81,8 +81,8 @@ class Audit:
     if len(coordinate.get_vulnerabilities()) == 0:
       if not self._quiet:
         self.do_print(
-            f"[{number}/{length}] - {coordinate.get_coordinates()} - "
-            f"no known vulnerabilities for this version", 0
+            f"[{number}/{length}] - {coordinate.get_coordinates()}",
+            0
         )
       return len(coordinate.get_vulnerabilities())
     self.do_print(

--- a/jake/audit/audit.py
+++ b/jake/audit/audit.py
@@ -22,112 +22,112 @@ from terminaltables import DoubleTable
 from ..types.coordinateresults import CoordinateResults
 from ..types.vulnerabilities import Vulnerabilities
 
-
 class Audit:
-    """ Audit does the business, it prints results from OSS Index to the standard out """
+  """ Audit does the business, it prints results from OSS Index to the standard out """
 
-    def __init__(self, quiet=False):
-        self._log = logging.getLogger("jake")
-        self._quiet = quiet
+  def __init__(self, quiet=False):
+    self._log = logging.getLogger("jake")
+    self._quiet = quiet
 
-    def audit_results(self, results: List[CoordinateResults]):
-        """
+  def audit_results(self, results: List[CoordinateResults]):
+    """
     audit_results is the ingest point for the results from OSS Index,
     and handles control flow
     """
-        self._log.debug("Results received, %s total results", len(results))
+    self._log.debug("Results received, %s total results", len(results))
 
-        total_vulns = 0
-        pkg_num = 0
+    total_vulns = 0
+    pkg_num = 0
 
-        for coordinate in results:
-            pkg_num += 1
-            total_vulns += self.print_result(coordinate, pkg_num, len(results))
+    for coordinate in results:
+      pkg_num += 1
+      total_vulns += self.print_result(coordinate, pkg_num, len(results))
 
-        table_data = [
-            ["Audited Dependencies", len(results)],
-            ["Vulnerablities Found", total_vulns],
-        ]
+    table_data = [
+        ["Audited Dependencies", len(results)],
+        ["Vulnerablities Found", total_vulns],
+    ]
 
-        table_instance = DoubleTable(table_data, "Summary")
+    table_instance = DoubleTable(table_data, "Summary")
 
-        print()
+    print()
 
-        print(table_instance.table)
+    print(table_instance.table)
 
-        return total_vulns
+    return total_vulns
 
-    def print_result(self, coordinate: CoordinateResults, number, length):
-        """
+  def print_result(self, coordinate: CoordinateResults, number, length):
+    """
     print_results takes a coordinate, the index of the coordinate in a list,
     and the length, and handles printing it in different formats if a
     vulnerability exists
     """
-        if len(coordinate.get_vulnerabilities()) == 0:
-            if not self._quiet:
-                self.do_print(
-                    f"[{number}/{length}] - {coordinate.get_coordinates()} - no known vulnerabilities for this version",
-                    0
-                )
-            return len(coordinate.get_vulnerabilities())
+    if len(coordinate.get_vulnerabilities()) == 0:
+      if not self._quiet:
         self.do_print(
-            f"[{number}/{length}] - {coordinate.get_coordinates()} [VULNERABLE] {len(coordinate.get_vulnerabilities())} known vulnerabilities for this version",
-            coordinate.get_max_cvss_score(),
+            f"[{number}/{length}] - {coordinate.get_coordinates()} - "
+            f"no known vulnerabilities for this version", 0
         )
-        for vulnerability in coordinate.get_vulnerabilities():
-            self.print_vulnerability(vulnerability)
-        return len(coordinate.get_vulnerabilities())
+      return len(coordinate.get_vulnerabilities())
+    self.do_print(
+        f"[{number}/{length}] - {coordinate.get_coordinates()} [VULNERABLE]" 
+        f"{len(coordinate.get_vulnerabilities())} known vulnerabilities for this version",
+        coordinate.get_max_cvss_score(),
+    )
+    for vulnerability in coordinate.get_vulnerabilities():
+      self.print_vulnerability(vulnerability)
+    return len(coordinate.get_vulnerabilities())
 
-    @classmethod
-    def print_vulnerability(cls, vulnerability: Vulnerabilities):
-        """
+  @classmethod
+  def print_vulnerability(cls, vulnerability: Vulnerabilities):
+    """
     print_vulnerability takes a vulnerability, and well, it prints it
     """
-        cvss_score = vulnerability.get_cvss_score()
-        cls.do_print(f"ID: {vulnerability.get_id()}", cvss_score)
-        cls.do_print(f"Title: {vulnerability.get_title()}", cvss_score)
-        cls.do_print(f"Description: {vulnerability.get_description()}", cvss_score)
-        cls.do_print(
-            f"CVSS Score: {vulnerability.get_cvss_score()} - {cls.get_cvss_severity(cvss_score)}",
-            cvss_score,
-        )
-        if vulnerability.get_cvss_vector() is not None:
-            cls.do_print(
-                f"CVSS Vector: {vulnerability.get_cvss_vector()}", cvss_score
-            )
-        cls.do_print(f"CVE: {vulnerability.get_cve()}", cvss_score)
-        cls.do_print(f"Reference: {vulnerability.get_reference()}", cvss_score)
-        print("----------------------------------------------------")
+    cvss_score = vulnerability.get_cvss_score()
+    cls.do_print(f"ID: {vulnerability.get_id()}", cvss_score)
+    cls.do_print(f"Title: {vulnerability.get_title()}", cvss_score)
+    cls.do_print(f"Description: {vulnerability.get_description()}", cvss_score)
+    cls.do_print(
+        f"CVSS Score: {vulnerability.get_cvss_score()} - {cls.get_cvss_severity(cvss_score)}",
+        cvss_score,
+    )
+    if vulnerability.get_cvss_vector() is not None:
+      cls.do_print(
+          f"CVSS Vector: {vulnerability.get_cvss_vector()}", cvss_score
+      )
+    cls.do_print(f"CVE: {vulnerability.get_cve()}", cvss_score)
+    cls.do_print(f"Reference: {vulnerability.get_reference()}", cvss_score)
+    print("----------------------------------------------------")
 
-    @classmethod
-    def do_print(cls, text, cvss_score):
-        """
+  @classmethod
+  def do_print(cls, text, cvss_score):
+    """
     do_print takes text, and a cvss_score and prints it in a different text depending on
     the score
     """
-        if cvss_score == 0:
-            print(Fore.GREEN + text + Fore.RESET)
-        elif 0 < cvss_score < 4:
-            print(Fore.CYAN + text + Fore.RESET)
-        elif 4 <= cvss_score < 7:
-            print(Fore.LIGHTYELLOW_EX + text + Fore.RESET)
-        elif 7 <= cvss_score < 9:
-            print(Fore.YELLOW + text + Fore.RESET)
-        else:
-            print(Fore.RED + text + Fore.RESET)
+    if cvss_score == 0:
+      print(Fore.GREEN + text + Fore.RESET)
+    elif 0 < cvss_score < 4:
+      print(Fore.CYAN + text + Fore.RESET)
+    elif 4 <= cvss_score < 7:
+      print(Fore.LIGHTYELLOW_EX + text + Fore.RESET)
+    elif 7 <= cvss_score < 9:
+      print(Fore.YELLOW + text + Fore.RESET)
+    else:
+      print(Fore.RED + text + Fore.RESET)
 
-    @classmethod
-    def get_cvss_severity(cls, cvss_score):
-        """
+  @classmethod
+  def get_cvss_severity(cls, cvss_score):
+    """
     get_cvss_severity takes a cvss_score and returns a human readable severity for it
     """
-        if cvss_score == 0:
-            return "None"
-        elif 0 < cvss_score < 4:
-            return "Low"
-        elif 4 <= cvss_score < 7:
-            return "Medium"
-        elif 7 <= cvss_score < 9:
-            return "High"
-        else:
-            return "Critical"
+    if cvss_score == 0:
+      return "None"
+    elif 0 < cvss_score < 4:
+      return "Low"
+    elif 4 <= cvss_score < 7:
+      return "Medium"
+    elif 7 <= cvss_score < 9:
+      return "High"
+    else:
+      return "Critical"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ colorama==0.4.3
 distlib==0.3.0
 idna==2.9
 isort==4.3.21
+-e git+git@github.com:sonatype-nexus-community/jake.git@322d367e6f49db5d0e8d9324a559c0d56f22a0e8#egg=jake
 johnnydep==1.5
 lazy-object-proxy==1.4.3
 lxml==4.5.0
@@ -26,6 +27,7 @@ six==1.14.0
 structlog==20.1.0
 tabulate==0.8.7
 termcolor==1.1.0
+terminaltables==3.1.0
 tinydb==3.15.2
 toml==0.10.0
 typed-ast==1.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ chardet==3.0.4
 click==7.1.2
 colorama==0.4.3
 distlib==0.3.0
-idna==2.7
+idna==2.9
 isort==4.3.21
 johnnydep==1.5
 lazy-object-proxy==1.4.3
@@ -21,7 +21,7 @@ pylint==2.5.0
 pyparsing==2.4.7
 python-dateutil==2.8.1
 PyYAML==5.3.1
-requests==2.19.0
+requests==2.23.0
 six==1.14.0
 structlog==20.1.0
 tabulate==0.8.7
@@ -30,7 +30,7 @@ terminaltables==3.1.0
 tinydb==3.15.2
 toml==0.10.0
 typed-ast==1.4.1
-urllib3==1.23
+urllib3==1.25.9
 wimpy==0.6
 wrapt==1.12.1
 yaspin==0.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ colorama==0.4.3
 distlib==0.3.0
 idna==2.7
 isort==4.3.21
--e git+git@github.com:sonatype-nexus-community/jake.git@ffa8a2907085db803fe0bef1f394ee3008fd3e28#egg=jake
 johnnydep==1.5
 lazy-object-proxy==1.4.3
 lxml==4.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@ chardet==3.0.4
 click==7.1.2
 colorama==0.4.3
 distlib==0.3.0
-idna==2.9
+idna==2.7
 isort==4.3.21
--e git+git@github.com:sonatype-nexus-community/jake.git@322d367e6f49db5d0e8d9324a559c0d56f22a0e8#egg=jake
+-e git+git@github.com:sonatype-nexus-community/jake.git@ffa8a2907085db803fe0bef1f394ee3008fd3e28#egg=jake
 johnnydep==1.5
 lazy-object-proxy==1.4.3
 lxml==4.5.0
@@ -22,7 +22,7 @@ pylint==2.5.0
 pyparsing==2.4.7
 python-dateutil==2.8.1
 PyYAML==5.3.1
-requests==2.23.0
+requests==2.19.0
 six==1.14.0
 structlog==20.1.0
 tabulate==0.8.7
@@ -31,7 +31,7 @@ terminaltables==3.1.0
 tinydb==3.15.2
 toml==0.10.0
 typed-ast==1.4.1
-urllib3==1.25.9
+urllib3==1.23
 wimpy==0.6
 wrapt==1.12.1
 yaspin==0.16.0


### PR DESCRIPTION
Okie dokie, based on some best practices from user testing, now we have dependencies grouped by if they are vulnerable or not vulnerable.

Vulnerabilities output in a table, and a summary is shown at the end.
<img width="511" alt="image" src="https://user-images.githubusercontent.com/34050448/83828584-044f1280-a6af-11ea-8e6c-3710fe1333a9.png">

Fixes #29 

cc @bhamail / @DarthHater
