### PR TITLE
Drop six as a dependency

### DIFF
--- a/jake/ossindex/ossindex.py
+++ b/jake/ossindex/ossindex.py
@@ -144,7 +144,10 @@ class OssIndex():
         cached = True
       else:
         print(result[0]['ttl'])
-        timetolive = DT.datetime.strptime(result[0]['ttl'], '%Y-%m-%dT%H:%M:%S.%f')
+        timetolive = DT.datetime.strptime(
+          result[0]['ttl'], 
+          '%Y-%m-%dT%H:%M:%S.%f'
+          )
         if mydatetime > timetolive:
           self._db.update({'response': coordinate.to_json(),
                            'ttl': twelvelater.isoformat()},
@@ -169,7 +172,10 @@ class OssIndex():
     for coordinate, purl in purls.get_coordinates().items():
       mydatetime = datetime.now()
       result = self._db.search(coordinate_query.purl == purl)
-      if len(result) == 0 or DT.datetime.strptime(result[0]['ttl'], '%Y-%m-%dT%H:%M:%S.%f') < mydatetime:
+      if len(result) == 0 or DT.datetime.strptime(
+        result[0]['ttl'], 
+        '%Y-%m-%dT%H:%M:%S.%f'
+        ) < mydatetime:
         new_purls.add_coordinate(coordinate[0], coordinate[1], coordinate[2])
       else:
         results.append(json.loads(

--- a/jake/ossindex/ossindex.py
+++ b/jake/ossindex/ossindex.py
@@ -143,7 +143,6 @@ class OssIndex():
         num_cached += 1
         cached = True
       else:
-        print(result[0]['ttl'])
         timetolive = DT.datetime.strptime(
           result[0]['ttl'],
           '%Y-%m-%dT%H:%M:%S.%f'

--- a/jake/ossindex/ossindex.py
+++ b/jake/ossindex/ossindex.py
@@ -17,11 +17,11 @@
 """ossindex.py makes a request to OSSIndex"""
 import logging
 import json
+import datetime as DT
 
 from typing import List
 from datetime import datetime, timedelta
 from pathlib import Path
-from dateutil.parser import parse
 from tinydb import TinyDB, Query
 
 import requests
@@ -143,7 +143,8 @@ class OssIndex():
         num_cached += 1
         cached = True
       else:
-        timetolive = parse(result[0]['ttl'])
+        print(result[0]['ttl'])
+        timetolive = DT.datetime.strptime(result[0]['ttl'], '%Y-%m-%dT%H:%M:%S.%f')
         if mydatetime > timetolive:
           self._db.update({'response': coordinate.to_json(),
                            'ttl': twelvelater.isoformat()},
@@ -168,7 +169,7 @@ class OssIndex():
     for coordinate, purl in purls.get_coordinates().items():
       mydatetime = datetime.now()
       result = self._db.search(coordinate_query.purl == purl)
-      if len(result) == 0 or parse(result[0]['ttl']) < mydatetime:
+      if len(result) == 0 or DT.datetime.strptime(result[0]['ttl'], '%Y-%m-%dT%H:%M:%S.%f') < mydatetime:
         new_purls.add_coordinate(coordinate[0], coordinate[1], coordinate[2])
       else:
         results.append(json.loads(

--- a/jake/ossindex/ossindex.py
+++ b/jake/ossindex/ossindex.py
@@ -145,7 +145,7 @@ class OssIndex():
       else:
         print(result[0]['ttl'])
         timetolive = DT.datetime.strptime(
-          result[0]['ttl'], 
+          result[0]['ttl'],
           '%Y-%m-%dT%H:%M:%S.%f'
           )
         if mydatetime > timetolive:
@@ -173,7 +173,7 @@ class OssIndex():
       mydatetime = datetime.now()
       result = self._db.search(coordinate_query.purl == purl)
       if len(result) == 0 or DT.datetime.strptime(
-        result[0]['ttl'], 
+        result[0]['ttl'],
         '%Y-%m-%dT%H:%M:%S.%f'
         ) < mydatetime:
         new_purls.add_coordinate(coordinate[0], coordinate[1], coordinate[2])

--- a/jake/test/test_ossindex.py
+++ b/jake/test/test_ossindex.py
@@ -17,12 +17,12 @@
 """test_ossindex.py audits the call to OSSIndex"""
 import unittest
 import json
+import datetime as DT
+
 from unittest.mock import patch
 from pathlib import Path
 from datetime import timedelta
 from tinydb import TinyDB, Query
-from dateutil.parser import parse
-
 
 from ..ossindex.ossindex import OssIndex
 from ..parse.parse import Parse
@@ -150,7 +150,7 @@ class TestOssIndex(unittest.TestCase):
     self.func.maybe_insert_into_cache(response)
     result_expired = database.search(
         coordinate_query.purl == "pkg:conda/pycrypto@2.6.1")
-    time_unwind = parse(result_expired[0]['ttl']) - timedelta(hours=13)
+    time_unwind = DT.datetime.strptime(result_expired[0]['ttl'], '%Y-%m-%dT%H:%M:%S.%f') - timedelta(hours=13)
     database.update({'ttl': time_unwind.isoformat()},
                     coordinate_query.purl == "pkg:conda/pycrypto@2.6.1")
 

--- a/jake/test/test_ossindex.py
+++ b/jake/test/test_ossindex.py
@@ -150,7 +150,9 @@ class TestOssIndex(unittest.TestCase):
     self.func.maybe_insert_into_cache(response)
     result_expired = database.search(
         coordinate_query.purl == "pkg:conda/pycrypto@2.6.1")
-    time_unwind = DT.datetime.strptime(result_expired[0]['ttl'], '%Y-%m-%dT%H:%M:%S.%f') - timedelta(hours=13)
+    time_unwind = DT.datetime.strptime(
+      result_expired[0]['ttl'],
+      '%Y-%m-%dT%H:%M:%S.%f') - timedelta(hours=13)
     database.update({'ttl': time_unwind.isoformat()},
                     coordinate_query.purl == "pkg:conda/pycrypto@2.6.1")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ pyfiglet==0.8.post1
 pyparsing==2.4.7
 PyYAML==5.3.1
 requests==2.23.0
-six==1.15.0
 tabulate==0.8.7
 termcolor==1.1.0
 terminaltables==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-anytree==2.8.0
-astroid==2.4.0
 cachetools==4.1.0
 certifi==2020.4.5.1
 chardet==3.0.4
@@ -8,7 +6,6 @@ colorama==0.4.3
 distlib==0.3.0
 idna==2.9
 isort==4.3.21
-johnnydep==1.5
 lazy-object-proxy==1.4.3
 lxml==4.5.0
 mccabe==0.6.1
@@ -17,13 +14,10 @@ packaging==20.3
 pkginfo==1.5.0.1
 polling==0.3.1
 pyfiglet==0.8.post1
-pylint==2.5.0
 pyparsing==2.4.7
-python-dateutil==2.8.1
 PyYAML==5.3.1
 requests==2.23.0
-six==1.14.0
-structlog==20.1.0
+six==1.15.0
 tabulate==0.8.7
 termcolor==1.1.0
 terminaltables==3.1.0


### PR DESCRIPTION
Basically six is causing a collision due to how we include it, so I wondered if we could just drop deps that need it, and this was the outcome!

This pull request makes the following changes:
* Removes unused libs from `requirements.txt`
* Removes `python-dateutil` by switching to using `datetime` and `strptime`

It relates to the following issue #s:
* Fixes #X

cc @bhamail / @DarthHater
