### PR TITLE
Allow insecure requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ Options:
   -t, --targets TEXT              List of site packages containing modules to
                                   be evaluated
 
+  -i, --insecure                  Allow jake to communicate with insecure
+                                  endpoints
+
   -a, --application TEXT          Supply an IQ Server Public Application ID
                                   [required]
 
@@ -128,6 +131,8 @@ Options:
 Run `jake config iq` to set the the endpoint and auth params.
 
 Once configured with proper credentials, run `jake iq -a <AppId>`, replacing `<AppId>` with the public ID of your application in Sonatype IQ. If a policy is violated that has the action set to `Fail` in IQ, `jake` will exit with a non zero code which can be picked up build automation or used to notify locally.
+
+If your Nexus IQ installation is using a self-signed certificate, you can run `jake` with the `-i` or `--insecure` flag to work with these types of installations.
 
 Each `jake` scan will generate a Software Bill of Materials (SBOM) in IQ and will output direct link to console.  The develop stage is used by default as opposed to other stages which usually correspond to component inventories of the latest build for a stage.
 

--- a/jake/__main__.py
+++ b/jake/__main__.py
@@ -86,11 +86,6 @@ __shared_options = [
         is_flag=True,
         help='Resolve conda dependencies from std_in'),
     click.option(
-        '-i', '--insecure',
-        default=False,
-        is_flag=True,
-        help='Allow jake to communicate with insecure endpoints'),
-    click.option(
         '-t', '--targets',
         default=None,
         help='List of site packages containing modules to be evaluated')
@@ -158,7 +153,7 @@ def config(conf):
 @click.option(
     '-o', '--output',
     help='Specify a file name and/or directory to save the CycloneDx sbom.')
-def sbom(verbose, quiet, conda, insecure, targets, output):
+def sbom(verbose, quiet, conda, targets, output):
   """
   Generates a purl only bom (no vulns) and outputs it to std_out a file
   by default or to a file path with the -o flag
@@ -202,7 +197,7 @@ def sbom(verbose, quiet, conda, insecure, targets, output):
 # ddt (ossi) subcommand
 @main.command()
 @__add_options(__shared_options)
-def ddt(verbose, quiet, conda, insecure, targets):
+def ddt(verbose, quiet, conda, targets):
   """SPECIAL MOVE\n
   Allows you to perform scans backed by Sonatype's OSS Index
 
@@ -243,6 +238,11 @@ def ddt(verbose, quiet, conda, insecure, targets):
 @main.command()
 @__add_options(__shared_options)
 @click.option(
+    '-i', '--insecure',
+    default=False,
+    is_flag=True,
+    help='Allow jake to communicate with insecure endpoints')
+@click.option(
     '-a', '--application',
     help='Supply an IQ Server Public Application ID',
     required=True)
@@ -260,8 +260,8 @@ def ddt(verbose, quiet, conda, insecure, targets):
 @click.option(
     '-h', '--host',
     help='Specify an endpoint for Sonatype IQ')
-def iq(verbose: bool, quiet: bool, conda: bool, insecure: bool, 
-       targets: str, application, stage, user, password, host):
+def iq(verbose: bool, quiet: bool, conda: bool, targets: str, 
+       insecure: bool, application, stage, user, password, host):
   """EXTRA SPECIAL MOVE\n
   Allows you to perform scans backed by Sonatype's Nexus IQ Server
 

--- a/jake/__main__.py
+++ b/jake/__main__.py
@@ -86,6 +86,11 @@ __shared_options = [
         is_flag=True,
         help='Resolve conda dependencies from std_in'),
     click.option(
+        '-i', '--insecure',
+        default=False,
+        is_flag=True,
+        help='Allow jake to communicate with insecure endpoints'),
+    click.option(
         '-t', '--targets',
         default=None,
         help='List of site packages containing modules to be evaluated')
@@ -153,7 +158,7 @@ def config(conf):
 @click.option(
     '-o', '--output',
     help='Specify a file name and/or directory to save the CycloneDx sbom.')
-def sbom(verbose, quiet, conda, targets, output):
+def sbom(verbose, quiet, conda, insecure, targets, output):
   """
   Generates a purl only bom (no vulns) and outputs it to std_out a file
   by default or to a file path with the -o flag
@@ -197,7 +202,7 @@ def sbom(verbose, quiet, conda, targets, output):
 # ddt (ossi) subcommand
 @main.command()
 @__add_options(__shared_options)
-def ddt(verbose, quiet, conda, targets):
+def ddt(verbose, quiet, conda, insecure, targets):
   """SPECIAL MOVE\n
   Allows you to perform scans backed by Sonatype's OSS Index
 
@@ -255,8 +260,8 @@ def ddt(verbose, quiet, conda, targets):
 @click.option(
     '-h', '--host',
     help='Specify an endpoint for Sonatype IQ')
-def iq(verbose: bool, quiet: bool, conda: bool, targets: str,
-       application, stage, user, password, host):
+def iq(verbose: bool, quiet: bool, conda: bool, insecure: bool, 
+       targets: str, application, stage, user, password, host):
   """EXTRA SPECIAL MOVE\n
   Allows you to perform scans backed by Sonatype's Nexus IQ Server
 
@@ -280,6 +285,7 @@ def iq(verbose: bool, quiet: bool, conda: bool, targets: str,
   iq_args['password'] = password
   iq_args['host'] = host
   iq_args['conda'] = conda
+  iq_args['insecure'] = insecure
 
   __iq_control_flow(iq_args, bom)
 

--- a/jake/__main__.py
+++ b/jake/__main__.py
@@ -260,7 +260,7 @@ def ddt(verbose, quiet, conda, targets):
 @click.option(
     '-h', '--host',
     help='Specify an endpoint for Sonatype IQ')
-def iq(verbose: bool, quiet: bool, conda: bool, targets: str, 
+def iq(verbose: bool, quiet: bool, conda: bool, targets: str,
        insecure: bool, application, stage, user, password, host):
   """EXTRA SPECIAL MOVE\n
   Allows you to perform scans backed by Sonatype's Nexus IQ Server

--- a/jake/iq/iq.py
+++ b/jake/iq/iq.py
@@ -43,6 +43,10 @@ class IQ():
     self._headers = DEFAULT_HEADERS
     self._report_url = ''
     self._policy_action = None
+    self._request = requests.Session()
+
+    if self._insecure:
+      self._request.verify = False
 
     config = IQConfig()
     if config.check_if_config_exists('.iq-server-config') is False:
@@ -63,6 +67,8 @@ class IQ():
       if self._iq_url is None:
         self._iq_url = results['Server']
 
+    self._request.auth = requests.auth.HTTPBasicAuth(self._user, self._password)
+
     self._internal_id = self.get_internal_id()
 
   def get_policy_action(self):
@@ -80,21 +86,11 @@ class IQ():
   def get_internal_id(self) -> (str):
     """gets internal application id from IQ Server using the public
     application id"""
-    if self._insecure:
-      response = requests.get(
-          '{0}/api/v2/applications?publicId={1}'.format(
-              self._iq_url,
-              self._public_application_id),
-          self._headers,
-          auth=(self._user, self._password),
-          verify=False)
-    else:
-      response = requests.get(
-          '{0}/api/v2/applications?publicId={1}'.format(
-              self._iq_url,
-              self._public_application_id),
-          self._headers,
-          auth=(self._user, self._password))
+    response = self._request.get(
+        '{0}/api/v2/applications?publicId={1}'.format(
+            self._iq_url,
+            self._public_application_id),
+        self._headers)
     if response.ok:
       res = json.loads(response.text)
       if not res['applications']:
@@ -112,25 +108,13 @@ class IQ():
     LOG.debug(sbom)
     headers = self._headers
     headers['Content-Type'] = 'application/xml'
-    if self._insecure:
-      response = requests.post(
-          '{0}/api/v2/scan/applications/{1}/sources/jake?stageId={2}'.format(
-              self._iq_url,
-              self._internal_id,
-              self._stage),
-          data=sbom,
-          headers=headers,
-          auth=(self._user, self._password),
-          verify=False)
-    else:
-      response = requests.post(
-          '{0}/api/v2/scan/applications/{1}/sources/jake?stageId={2}'.format(
-              self._iq_url,
-              self._internal_id,
-              self._stage),
-          data=sbom,
-          headers=headers,
-          auth=(self._user, self._password))
+    response = self._request.post(
+        '{0}/api/v2/scan/applications/{1}/sources/jake?stageId={2}'.format(
+            self._iq_url,
+            self._internal_id,
+            self._stage),
+        data=sbom,
+        headers=headers)
     if response.ok:
       res = json.loads(response.text)
       LOG.debug(res['statusUrl'])
@@ -140,22 +124,12 @@ class IQ():
   def poll_report(self, status_url: str):
     """polls status url once a second until it gets a 200 response
     , and times out after one minute"""
-    if self._insecure:
-      polling.poll(
-          lambda: requests.get(
-              '{0}/{1}'.format(self._iq_url, status_url),
-              auth=(self._user, self._password), verify=False).text,
-          check_success=self.__handle_response,
-          step=1,
-          timeout=60)
-    else:
-      polling.poll(
-          lambda: requests.get(
-              '{0}/{1}'.format(self._iq_url, status_url),
-              auth=(self._user, self._password)).text,
-          check_success=self.__handle_response,
-          step=1,
-          timeout=60)
+    polling.poll(
+        lambda: self._request.get(
+            '{0}/{1}'.format(self._iq_url, status_url)).text,
+        check_success=self.__handle_response,
+        step=1,
+        timeout=60)
 
   def __handle_response(self, response: str) -> (bool):
     try:

--- a/jake/iq/iq.py
+++ b/jake/iq/iq.py
@@ -90,7 +90,7 @@ class IQ():
         '{0}/api/v2/applications?publicId={1}'.format(
             self._iq_url,
             self._public_application_id),
-        self._headers)
+        headers=self._headers)
     if response.ok:
       res = json.loads(response.text)
       if not res['applications']:


### PR DESCRIPTION
This PR allows insecure requests to be made (only to IQ Server, we generally know OSS Index should be secure)

This pull request makes the following changes:
* Adds a `-i` or `--insecure` flag to the `iq` command
* Modifies the IQ server class to be a bit "better", setting up a shared session, and setting config on it where we know it's global

cc @bhamail / @DarthHater
