### PR TITLE
Handle IQ warning

### DIFF
--- a/jake/__main__.py
+++ b/jake/__main__.py
@@ -342,6 +342,14 @@ def __iq_control_flow(args: dict, bom_str: bytes):
       print(Fore.YELLOW +
             "Your IQ Server Report is available here: {}".format(iq_requests.get_report_url()))
       _exit(1)
+    elif iq_requests.get_policy_action() == 'Warning':
+      spinner.ok("🧨 ")
+      __toggle_stdout(on=True)
+      print(Fore.GREEN +
+            "Warning, something slithers around your ankle! There are policy warnings from Sonatype IQ.")
+      print(Fore.GREEN +
+            "Your IQ Server Report is available here: {}".format(iq_requests.get_report_url()))
+      _exit(0)
     elif iq_requests.get_policy_action() == 'None':
       spinner.ok("🐍 ")
       __toggle_stdout(on=True)

--- a/jake/__main__.py
+++ b/jake/__main__.py
@@ -346,7 +346,7 @@ def __iq_control_flow(args: dict, bom_str: bytes):
       spinner.ok("🧨 ")
       __toggle_stdout(on=True)
       print(Fore.GREEN +
-            "Warning, something slithers around your ankle! There are policy warnings from Sonatype IQ.")
+            "Something slithers around your ankle! There are policy warnings from Sonatype IQ.")
       print(Fore.GREEN +
             "Your IQ Server Report is available here: {}".format(iq_requests.get_report_url()))
       _exit(0)

--- a/jake/test/iqpolicywarningresponse.txt
+++ b/jake/test/iqpolicywarningresponse.txt
@@ -1,0 +1,16 @@
+{
+    "policyAction": "Warning",
+    "reportHtmlUrl": "http://localhost:8070/ui/links/application/my-app/report/95c4c14e",
+    "isError": false,
+    "componentsAffected": {
+        "critical": 1,
+        "severe": 0,
+        "moderate": 0
+    },
+    "openPolicyViolations": {
+        "critical": 2,
+        "severe": 1,
+        "moderate": 0
+    },
+    "grandfatheredPolicyViolations": 0
+}

--- a/jake/test/test_iq.py
+++ b/jake/test/test_iq.py
@@ -120,3 +120,19 @@ class TestIQ(unittest.TestCase):
 
       self.func.poll_report(self.status_url)
     self.assertEqual(self.func.get_policy_action(), 'Failure')
+
+  @responses.activate
+  def test_call_poll_report_warning_policy_action(self):
+    """test_call_poll_report_warning_policy_action mocks a call to IQ
+    and ensures that that calls to IQ asking for a poll
+    response on a status URL, return as expected, and sets policy action
+    to Warning"""
+    file = Path(__file__).parent / "iqpolicywarningresponse.txt"
+    with open(file, "r") as stdin:
+      mock_json = json.loads(stdin.read())
+      responses.add(responses.GET,
+                    self.full_status_url,
+                    json=mock_json, status=200)
+
+      self.func.poll_report(self.status_url)
+    self.assertEqual(self.func.get_policy_action(), 'Warning')


### PR DESCRIPTION
IQ Rest API can return a `Warning` policyAction value. This PR handles that case. A `Warning` will not return an error status code.

cc @bhamail / @DarthHater
