### PR TITLE
remove extension parameter suffix from sbom 'version' tag. 

### DIFF
--- a/jake/cyclonedx/v1_1/generator.py
+++ b/jake/cyclonedx/v1_1/generator.py
@@ -110,7 +110,8 @@ class CycloneDx11Generator():
   def __get_name_version_from_purl(purl):
     split_list = purl.split("/")
     second_split = split_list[1].split("@")
-    return (second_split[0], second_split[1])
+    version_split = second_split[1].split("?")
+    return (second_split[0], version_split[0])
 
   @staticmethod
   def __create_vulnerability_node(vulnerability_list, purl, vulnerabilities, node):

--- a/jake/test/test_sbom_generator.py
+++ b/jake/test/test_sbom_generator.py
@@ -64,6 +64,8 @@ class TestSbomGenerator(unittest.TestCase):
     self.assertEqual(vulnerabilities.__len__(), 5)
 
   def test__get_name_version_from_purl(self):
+    """test__get_name_version_from_purl tests if a parameter suffix is removed from the
+    sbom version field"""
     coord_result = CoordinateResults()
     coord_result.set_coordinates("pkg:pypi/yaspin@0.16.0?extension=tar.gz")
     coord_result_normal = CoordinateResults()


### PR DESCRIPTION
remove any `?` parameter suffix from the `version` value shown in the generated sbom.

For example, a purl with: `pkg:pypi/yaspin@0.16.0?extension=tar.gz` will now produce an sbom version: `0.16.0`.
Prior to this fix, the version would include the parameter suffix like so: `0.16.0?extension=tar.gz`

Verified that non-suffixed purl still produces a proper version. e.g; purl: `pkg:pypi/normalpurl@0.17.0` produces version `0.17.0`.

It relates to the following issue #s:
* Fixes #43

cc @bhamail / @DarthHater
