### PR TITLE
use an absolute report url (handle IQ 104+)

### DIFF
--- a/jake/__main__.py
+++ b/jake/__main__.py
@@ -334,37 +334,47 @@ def __iq_control_flow(args: dict, bom_str: bytes):
     spinner.text = "Reticulating splines..."
     iq_requests.poll_report(status_url)
 
+    exit_status_code = _show_summary(iq_requests, spinner)
+    _exit(exit_status_code)
+
+
+def _show_summary(iq_requests, spinner):
     if iq_requests.get_policy_action() == 'Failure':
-      spinner.fail("💥 ")
-      __toggle_stdout(on=True)
-      print(Fore.YELLOW +
-            "Snakes on the plane! There are policy failures from Sonatype IQ.")
-      print(Fore.YELLOW +
-            "Your IQ Server Report is available here: {}".format(iq_requests.get_report_url()))
-      _exit(1)
+        spinner.fail("💥 ")
+        __toggle_stdout(on=True)
+        print(Fore.RED +
+              "Snakes on the plane! There are policy failures from Sonatype IQ.")
+        print(Fore.RED +
+              "Your IQ Server Report is available here: {}".format(iq_requests.get_absolute_report_url()))
+        exit_status_code = 1
     elif iq_requests.get_policy_action() == 'Warning':
-      spinner.ok("🧨 ")
-      __toggle_stdout(on=True)
-      print(Fore.GREEN +
-            "Something slithers around your ankle! There are policy warnings from Sonatype IQ.")
-      print(Fore.GREEN +
-            "Your IQ Server Report is available here: {}".format(iq_requests.get_report_url()))
-      _exit(0)
+        spinner.ok("🧨 ")
+        __toggle_stdout(on=True)
+        print(Fore.YELLOW +
+              "Something slithers around your ankle! There are policy warnings from Sonatype IQ.")
+        print(Fore.YELLOW +
+              "Your IQ Server Report is available here: {}".format(iq_requests.get_absolute_report_url()))
+        exit_status_code = 0
     elif iq_requests.get_policy_action() == 'None':
-      spinner.ok("🐍 ")
-      __toggle_stdout(on=True)
-      print(Fore.GREEN +
-            "Smooth slithering there bud! No policy failures from Sonatype IQ.")
-      print(Fore.GREEN +
-            "Your IQ Server Report is available here: {}".format(iq_requests.get_report_url()))
-      _exit(0)
+        spinner.ok("🐍 ")
+        __toggle_stdout(on=True)
+        print(Fore.GREEN +
+              "Smooth slithering there bud! No policy failures from Sonatype IQ.")
+        print(Fore.GREEN +
+              "Your IQ Server Report is available here: {}".format(iq_requests.get_absolute_report_url()))
+        exit_status_code = 0
     else:
-      spinner.fail("🐍 ")
-      __toggle_stdout(on=True)
-      print(Fore.RED +
-            "Received an error response from IQ Server, please check logs. policy action: {}"
-            .format(iq_requests.get_policy_action()))
-      _exit(3)
+        spinner.fail("🐍 ")
+        __toggle_stdout(on=True)
+        print(Fore.RED +
+              "Received an error response from IQ Server, please check logs. policy action: {}"
+              .format(iq_requests.get_policy_action()))
+        exit_status_code = 3
+
+    # reset console colors, etc
+    print(Fore.RESET)
+    return exit_status_code
+
 
 def __sbom_control_flow(conda: bool, target: str) -> (bytes):
   """

--- a/jake/__main__.py
+++ b/jake/__main__.py
@@ -339,41 +339,41 @@ def __iq_control_flow(args: dict, bom_str: bytes):
 
 
 def _show_summary(iq_requests, spinner):
-    if iq_requests.get_policy_action() == 'Failure':
-        spinner.fail("💥 ")
-        __toggle_stdout(on=True)
-        print(Fore.RED +
-              "Snakes on the plane! There are policy failures from Sonatype IQ.")
-        print(Fore.RED +
-              "Your IQ Server Report is available here: {}".format(iq_requests.get_absolute_report_url()))
-        exit_status_code = 1
-    elif iq_requests.get_policy_action() == 'Warning':
-        spinner.ok("🧨 ")
-        __toggle_stdout(on=True)
-        print(Fore.YELLOW +
-              "Something slithers around your ankle! There are policy warnings from Sonatype IQ.")
-        print(Fore.YELLOW +
-              "Your IQ Server Report is available here: {}".format(iq_requests.get_absolute_report_url()))
-        exit_status_code = 0
-    elif iq_requests.get_policy_action() == 'None':
-        spinner.ok("🐍 ")
-        __toggle_stdout(on=True)
-        print(Fore.GREEN +
-              "Smooth slithering there bud! No policy failures from Sonatype IQ.")
-        print(Fore.GREEN +
-              "Your IQ Server Report is available here: {}".format(iq_requests.get_absolute_report_url()))
-        exit_status_code = 0
-    else:
-        spinner.fail("🐍 ")
-        __toggle_stdout(on=True)
-        print(Fore.RED +
-              "Received an error response from IQ Server, please check logs. policy action: {}"
-              .format(iq_requests.get_policy_action()))
-        exit_status_code = 3
+  if iq_requests.get_policy_action() == 'Failure':
+    spinner.fail("💥 ")
+    __toggle_stdout(on=True)
+    print(Fore.RED +
+          "Snakes on the plane! There are policy failures from Sonatype IQ.")
+    print(Fore.RED + "Your IQ Server Report is available here: {}"
+          .format(iq_requests.get_absolute_report_url()))
+    exit_status_code = 1
+  elif iq_requests.get_policy_action() == 'Warning':
+    spinner.ok("🧨 ")
+    __toggle_stdout(on=True)
+    print(Fore.YELLOW +
+          "Something slithers around your ankle! There are policy warnings from Sonatype IQ.")
+    print(Fore.YELLOW + "Your IQ Server Report is available here: {}"
+          .format(iq_requests.get_absolute_report_url()))
+    exit_status_code = 0
+  elif iq_requests.get_policy_action() == 'None':
+    spinner.ok("🐍 ")
+    __toggle_stdout(on=True)
+    print(Fore.GREEN +
+          "Smooth slithering there bud! No policy failures from Sonatype IQ.")
+    print(Fore.GREEN + "Your IQ Server Report is available here: {}"
+          .format(iq_requests.get_absolute_report_url()))
+    exit_status_code = 0
+  else:
+    spinner.fail("🐍 ")
+    __toggle_stdout(on=True)
+    print(Fore.RED +
+          "Received an error response from IQ Server, please check logs. policy action: {}"
+          .format(iq_requests.get_policy_action()))
+    exit_status_code = 3
 
-    # reset console colors, etc
-    print(Fore.RESET)
-    return exit_status_code
+  # reset console colors, etc
+  print(Fore.RESET)
+  return exit_status_code
 
 
 def __sbom_control_flow(conda: bool, target: str) -> (bytes):

--- a/jake/__main__.py
+++ b/jake/__main__.py
@@ -334,8 +334,7 @@ def __iq_control_flow(args: dict, bom_str: bytes):
     spinner.text = "Reticulating splines..."
     iq_requests.poll_report(status_url)
 
-    exit_status_code = _show_summary(iq_requests, spinner)
-    _exit(exit_status_code)
+    _exit(_show_summary(iq_requests, spinner))
 
 
 def _show_summary(iq_requests, spinner):

--- a/jake/iq/iq.py
+++ b/jake/iq/iq.py
@@ -18,6 +18,7 @@
 # pylint: disable=too-many-instance-attributes
 import json
 import logging
+import urllib
 
 from json import JSONDecodeError
 
@@ -77,6 +78,10 @@ class IQ():
   def get_report_url(self):
     """gets report url from IQ Server result"""
     return self._report_url
+
+  def get_absolute_report_url(self):
+    """get full (non-relative) url to IQ Server report"""
+    return urllib.parse.urljoin(self._iq_url, self._report_url)
 
   def get_public_application_id(self) -> (str):
     """gets public application id to use for IQ Server request"""

--- a/jake/iq/iq.py
+++ b/jake/iq/iq.py
@@ -81,6 +81,7 @@ class IQ():
 
   def get_absolute_report_url(self):
     """get full (non-relative) url to IQ Server report"""
+    # urljoin() will ignore the first parameter (base) if the second parameter (url) is absolute
     return urllib.parse.urljoin(self._iq_url, self._report_url)
 
   def get_public_application_id(self) -> (str):

--- a/jake/test/iqresponse_absolute_report_url.json
+++ b/jake/test/iqresponse_absolute_report_url.json
@@ -1,0 +1,16 @@
+{
+    "policyAction": "Warning",
+    "reportHtmlUrl": "http://localhost:8070/ui/links/application/my-app/report/95c4c14e",
+    "isError": false,
+    "componentsAffected": {
+        "critical": 1,
+        "severe": 0,
+        "moderate": 0
+    },
+    "openPolicyViolations": {
+        "critical": 2,
+        "severe": 1,
+        "moderate": 0
+    },
+    "grandfatheredPolicyViolations": 0
+}

--- a/jake/test/iqresponse_relative_report_url.json
+++ b/jake/test/iqresponse_relative_report_url.json
@@ -1,0 +1,16 @@
+{
+    "policyAction": "Warning",
+    "reportHtmlUrl": "ui/links/application/my-app/report/95c4c14e",
+    "isError": false,
+    "componentsAffected": {
+        "critical": 1,
+        "severe": 0,
+        "moderate": 0
+    },
+    "openPolicyViolations": {
+        "critical": 2,
+        "severe": 1,
+        "moderate": 0
+    },
+    "grandfatheredPolicyViolations": 0
+}

--- a/jake/test/test_iq.py
+++ b/jake/test/test_iq.py
@@ -146,16 +146,20 @@ class TestIQ(unittest.TestCase):
                     json=mock_json, status=200)
 
       self.func.poll_report(self.status_url)
+    # pylint: disable=W0212
     self.assertEqual(self.func._iq_url, 'http://afakeurlthatdoesnotexist.com:8081')
-    self.assertEqual(self.func.get_report_url(), 'http://localhost:8070/ui/links/application/my-app/report/95c4c14e')
+    self.assertEqual(self.func.get_report_url(),
+                     'http://localhost:8070/ui/links/application/my-app/report/95c4c14e')
     # ensure we use the IQ provided absolute URL
-    self.assertEqual(self.func.get_absolute_report_url(), 'http://localhost:8070/ui/links/application/my-app/report/95c4c14e')
+    self.assertEqual(self.func.get_absolute_report_url(),
+                     'http://localhost:8070/ui/links/application/my-app/report/95c4c14e')
 
   @responses.activate
   def test_call_poll_report_relative_result_url(self):
     """test_call_poll_report_relative_result_url mocks a call to IQ
     and ensures a relative report URL is returned,
-    and ensure get_absolute_report_url() returns an absolute URL build from the _iq_url and relative report URL"""
+    and ensure get_absolute_report_url() returns an absolute URL
+    built from the _iq_url and relative report URL"""
     file = Path(__file__).parent / "iqresponse_relative_report_url.json"
     with open(file, "r") as stdin:
       mock_json = json.loads(stdin.read())
@@ -164,7 +168,10 @@ class TestIQ(unittest.TestCase):
                     json=mock_json, status=200)
 
       self.func.poll_report(self.status_url)
+    # pylint: disable=W0212
     self.assertEqual(self.func._iq_url, 'http://afakeurlthatdoesnotexist.com:8081')
-    self.assertEqual(self.func.get_report_url(), 'ui/links/application/my-app/report/95c4c14e')
+    self.assertEqual(self.func.get_report_url(),
+                     'ui/links/application/my-app/report/95c4c14e')
     # build the absolute URL from the IQ Server base url
-    self.assertEqual(self.func.get_absolute_report_url(), 'http://afakeurlthatdoesnotexist.com:8081/ui/links/application/my-app/report/95c4c14e')
+    self.assertEqual(self.func.get_absolute_report_url(),
+        'http://afakeurlthatdoesnotexist.com:8081/ui/links/application/my-app/report/95c4c14e')

--- a/jake/test/test_iq.py
+++ b/jake/test/test_iq.py
@@ -23,10 +23,6 @@ from pathlib import Path
 import responses
 
 from ..iq.iq import IQ
-# from ..types.coordinates import Coordinates
-# from ..types.coordinateresults import CoordinateResults
-# from ..types.results_decoder import ResultsDecoder
-# from ..types.vulnerabilities import Vulnerabilities
 
 class TestIQ(unittest.TestCase):
   """TestIQ audits the call to IQ"""
@@ -136,3 +132,39 @@ class TestIQ(unittest.TestCase):
 
       self.func.poll_report(self.status_url)
     self.assertEqual(self.func.get_policy_action(), 'Warning')
+
+  @responses.activate
+  def test_call_poll_report_absolute_result_url(self):
+    """test_call_poll_report_relative_result_url mocks a call to IQ
+    and ensures an absolute report URL is returned,
+    and ensure that same absolute report URL is returned from get_absolute_report_url()"""
+    file = Path(__file__).parent / "iqresponse_absolute_report_url.json"
+    with open(file, "r") as stdin:
+      mock_json = json.loads(stdin.read())
+      responses.add(responses.GET,
+                    self.full_status_url,
+                    json=mock_json, status=200)
+
+      self.func.poll_report(self.status_url)
+    self.assertEqual(self.func._iq_url, 'http://afakeurlthatdoesnotexist.com:8081')
+    self.assertEqual(self.func.get_report_url(), 'http://localhost:8070/ui/links/application/my-app/report/95c4c14e')
+    # ensure we use the IQ provided absolute URL
+    self.assertEqual(self.func.get_absolute_report_url(), 'http://localhost:8070/ui/links/application/my-app/report/95c4c14e')
+
+  @responses.activate
+  def test_call_poll_report_relative_result_url(self):
+    """test_call_poll_report_relative_result_url mocks a call to IQ
+    and ensures a relative report URL is returned,
+    and ensure get_absolute_report_url() returns an absolute URL build from the _iq_url and relative report URL"""
+    file = Path(__file__).parent / "iqresponse_relative_report_url.json"
+    with open(file, "r") as stdin:
+      mock_json = json.loads(stdin.read())
+      responses.add(responses.GET,
+                    self.full_status_url,
+                    json=mock_json, status=200)
+
+      self.func.poll_report(self.status_url)
+    self.assertEqual(self.func._iq_url, 'http://afakeurlthatdoesnotexist.com:8081')
+    self.assertEqual(self.func.get_report_url(), 'ui/links/application/my-app/report/95c4c14e')
+    # build the absolute URL from the IQ Server base url
+    self.assertEqual(self.func.get_absolute_report_url(), 'http://afakeurlthatdoesnotexist.com:8081/ui/links/application/my-app/report/95c4c14e')

--- a/jake/test/test_main.py
+++ b/jake/test/test_main.py
@@ -24,27 +24,27 @@ from jake.iq.iq import IQ
 
 
 class TestMain(unittest.TestCase):
-    """TestMain tests stuff in __main__"""
+  """TestMain tests stuff in __main__"""
 
-    def setUp(self):
-        iq_args = {}
-        self.func = IQ(args=iq_args)
+  def setUp(self):
+    iq_args = {}
+    self.func = IQ(args=iq_args)
 
-    def test_show_summary(self):
-        """test_show_summary verifies exit code is correct
-    for a given IQ Policy Action"""
-        spinner = yaspin(text="Loading", color="magenta")
+  def test_show_summary(self):
+    """test_show_summary verifies exit code is correct for a given IQ Policy Action"""
+    spinner = yaspin(text="Loading", color="magenta")
 
-        self.func._report_url = 'myRelativeReportURL'
+    # pylint: disable=W0212
+    self.func._report_url = 'myRelativeReportURL'
 
-        self.func._policy_action = None
-        self.assertEqual(3, _show_summary(self.func, spinner))
+    self.func._policy_action = None
+    self.assertEqual(3, _show_summary(self.func, spinner))
 
-        self.func._policy_action = "Failure"
-        self.assertEqual(1, _show_summary(self.func, spinner))
+    self.func._policy_action = "Failure"
+    self.assertEqual(1, _show_summary(self.func, spinner))
 
-        self.func._policy_action = "Warning"
-        self.assertEqual(0, _show_summary(self.func, spinner))
+    self.func._policy_action = "Warning"
+    self.assertEqual(0, _show_summary(self.func, spinner))
 
-        self.func._policy_action = "None"
-        self.assertEqual(0, _show_summary(self.func, spinner))
+    self.func._policy_action = "None"
+    self.assertEqual(0, _show_summary(self.func, spinner))

--- a/jake/test/test_main.py
+++ b/jake/test/test_main.py
@@ -1,0 +1,50 @@
+#
+# Copyright 2019-Present Sonatype Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""test_main.py test stuff in __main__.py"""
+import unittest
+
+from yaspin import yaspin
+
+from jake.__main__ import _show_summary
+from jake.iq.iq import IQ
+
+
+class TestMain(unittest.TestCase):
+    """TestMain tests stuff in __main__"""
+
+    def setUp(self):
+        iq_args = {}
+        self.func = IQ(args=iq_args)
+
+    def test_show_summary(self):
+        """test_show_summary verifies exit code is correct
+    for a given IQ Policy Action"""
+        spinner = yaspin(text="Loading", color="magenta")
+
+        self.func._report_url = 'myRelativeReportURL'
+
+        self.func._policy_action = None
+        self.assertEqual(3, _show_summary(self.func, spinner))
+
+        self.func._policy_action = "Failure"
+        self.assertEqual(1, _show_summary(self.func, spinner))
+
+        self.func._policy_action = "Warning"
+        self.assertEqual(0, _show_summary(self.func, spinner))
+
+        self.func._policy_action = "None"
+        self.assertEqual(0, _show_summary(self.func, spinner))


### PR DESCRIPTION
Newer versions of IQ (104+) respond with a relative report URL. This PR ensures an absolute report url will be shown to the user, regardless of which IQ version is being used.

Also tweaks the coloring of the display.
1. It used to leave the console set to whatever color was last printed. Now resets console color.
2. Tweaked colors of for policy actions:



cc @bhamail / @DarthHater
