### PR TITLE
Add json output format for ddt command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Options:
   -c, --conda               Resolve conda dependencies from std_in
   -t, --targets       TEXT  List of site packages containing modules to be evaluated
   -r, --requirements  TEXT  Path of pip requirements file
+  -o, --output-format TEXT  Specify ddt output format(json or hr=human-
+                            readable)
   --help                    Show this message and exit.
 ```
 

--- a/README.md
+++ b/README.md
@@ -364,4 +364,3 @@ Have fun creating and using `jake` and the [Sonatype OSS Index](https://ossindex
 Looking to contribute to our code but need some help? There's a few ways to get information:
 
 * Chat with us on [Gitter](https://gitter.im/sonatype/nexus-developers)
-

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Options:
   -vv, --verbose                  Set log level to verbose
   -q, --quiet                     Suppress cosmetic and informational output
   -c, --conda                     Resolve conda dependencies from std_in
-  -r, --requirements  TEXT        Path of pip requirements file
+
   -t, --targets TEXT              Specify external site-packages to evaluate.
                                   
                                   "`python -c "import site;
@@ -117,6 +117,8 @@ Options:
                                   
                                   Passing the above into -t targets site packages for the
                                   current shell/venv
+
+  -r, --requirements  TEXT        Path of pip requirements file
 
   -i, --insecure                  Allow jake to communicate with insecure
                                   endpoints

--- a/README.md
+++ b/README.md
@@ -364,3 +364,5 @@ Have fun creating and using `jake` and the [Sonatype OSS Index](https://ossindex
 Looking to contribute to our code but need some help? There's a few ways to get information:
 
 * Chat with us on [Gitter](https://gitter.im/sonatype/nexus-developers)
+
+

--- a/README.md
+++ b/README.md
@@ -365,4 +365,3 @@ Looking to contribute to our code but need some help? There's a few ways to get 
 
 * Chat with us on [Gitter](https://gitter.im/sonatype/nexus-developers)
 
-

--- a/jake/__main__.py
+++ b/jake/__main__.py
@@ -204,7 +204,10 @@ def sbom(verbose, quiet, conda, targets, requirements, output):
 # ddt (ossi) subcommand
 @main.command()
 @__add_options(__shared_options)
-def ddt(verbose, quiet, conda, targets, requirements):
+@click.option(
+    '-o', '--output-format',
+    help='Specify ddt output format(json or hr=human-readable)')
+def ddt(verbose, quiet, conda, targets, requirements, output_format='hr'):
   """SPECIAL MOVE\n
   Allows you to perform scans backed by Sonatype's OSS Index
 
@@ -212,9 +215,13 @@ def ddt(verbose, quiet, conda, targets, requirements):
       Python scan: jake ddt\n
       Conda scan: conda list | jake ddt -c\n
   """
-  __banner(quiet)
   __setup_logger(verbose)
   __check_stdin(conda)
+
+  if output_format == 'json':
+    __toggle_stdout(on=False)
+
+  __banner(quiet)
 
   with yaspin(text="Loading", color="yellow") as spinner:
     spinner.text = "Collecting Dependencies"
@@ -243,7 +250,7 @@ def ddt(verbose, quiet, conda, targets, requirements):
     audit = Audit(quiet)
     spinner.ok("🐍 ")
     __toggle_stdout(on=True)
-    code = audit.audit_results(response)
+    code = audit.audit_results(response, output_format=output_format)
     _exit(code)
 
 @main.command()

--- a/jake/__main__.py
+++ b/jake/__main__.py
@@ -406,9 +406,9 @@ def __sbom_control_flow(conda: bool, target: str, requirements_file_path: str) -
   with yaspin(text="Loading", color="yellow") as spinner:
     spinner.text = "Collecting Dependencies from System..."
     coords = (
-        Parse().get_deps_stdin(sys.stdin)
-        if conda
-        else Pip(target, requirements_file_path).get_dependencies()
+      Parse().get_deps_stdin(sys.stdin)
+      if conda
+      else Pip(target, requirements_file_path).get_dependencies()
     )
     spinner.ok("🐍 ")
     spinner.text = "Parsing Coordinates..."

--- a/jake/audit/audit.py
+++ b/jake/audit/audit.py
@@ -80,7 +80,11 @@ class Audit:
     return total_vulns
 
   @classmethod
-  def print_results_json(cls, results):
+  def print_results_json(cls, results: List[CoordinateResults]):
+    """
+    print_json takes a list of coordinate results,
+    and prints a json array of all vulnerabilities
+    """
     vulnerabilities = []
     for result in results:
       for vulnerability in result.get_vulnerabilities():

--- a/jake/pip/pip.py
+++ b/jake/pip/pip.py
@@ -31,7 +31,7 @@ class Pip():
     self.requirements_file_path = requirements_file_path
     if targets:
       self._working_set = pkg_resources.WorkingSet(ast.literal_eval(targets))
-    self._coords = self.generate_dependencies()
+    self.__coords = self.generate_dependencies()
 
   def generate_dependencies(self, coords=Coordinates()) -> (Coordinates):
     """converts list of pkg_resource.working_set into purl coordinates"""

--- a/jake/pip/pip.py
+++ b/jake/pip/pip.py
@@ -31,7 +31,7 @@ class Pip():
     self.requirements_file_path = requirements_file_path
     if targets:
       self._working_set = pkg_resources.WorkingSet(ast.literal_eval(targets))
-    self.__coords = self.generate_dependencies()
+    self._coords = self.generate_dependencies()
 
   def generate_dependencies(self, coords=Coordinates()) -> (Coordinates):
     """converts list of pkg_resource.working_set into purl coordinates"""


### PR DESCRIPTION
Currently `ddt` can only print output in human readable format. This PR adds the option to print found vulnerabilities only in JSON format.

This pull request makes the following changes:
* Adds `-o, --output-format` flag for `ddt` command

cc @bhamail / @DarthHater
