### PR TITLE
Inline targets help changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,13 @@ Options:
   -vv, --verbose                  Set log level to verbose
   -q, --quiet                     Suppress cosmetic and informational output
   -c, --conda                     Resolve conda dependencies from std_in
-  -t, --targets TEXT              List of site packages containing modules to
-                                  be evaluated
+  -t, --targets TEXT              Specify external site-packages to evaluate.
+                                  
+                                  "`python -c "import site;
+                                  print(site.getsitepackages())"`"
+                                  
+                                  Passing the above into -t targets site packages for the
+                                  current shell/venv
 
   -i, --insecure                  Allow jake to communicate with insecure
                                   endpoints

--- a/README.md
+++ b/README.md
@@ -253,9 +253,15 @@ To get the site packages available to a virtual environment:
   ENABLE_USER_SITE: False
 ```
 
-The `-t` argument accepts a list as a string literal.  This is the best way I've found to do this, if you find a better way please create an issue :)
+The `-t` argument accepts a list as a string literal.  This is the best way I've found to do this, if you find a better way please create a PR :)
 
-Run the python command using the shell you want to target and export to an env var:
+You can either enter a virtual environment and run the python command to get the site packages in-line with the `-t` argument:
+```
+  $ source .venv/bin/activate
+  (.venv) $ jake ddt -t "`python -c "import site; print(site.getsitepackages())"`"
+```
+
+OR run the python command using the shell you want to target and export to an env var:
 
 ```
   # using target python shell for system or virtual environment
@@ -263,8 +269,6 @@ Run the python command using the shell you want to target and export to an env v
   # using whatever shell has access to the jake module, can be a global install or stand-alone virtual environment
   $ jake ddt -t "$JAKE_TARGET"
 ```
-
-In other words: activate the virtual environment, run the `site.getsitepackages()` command, and make the output accessible to your `jake` install
 
 This will work for the `ddt`, `iq`, and `sbom` subcommands when evaluating pip modules.
 

--- a/jake/__main__.py
+++ b/jake/__main__.py
@@ -88,7 +88,10 @@ __shared_options = [
     click.option(
         '-t', '--targets',
         default=None,
-        help='List of site packages containing modules to be evaluated')
+        help="""Specify external site-packages to evaluate.\n
+                "`python -c "import site; print(site.getsitepackages())"`"\n
+                Passing the above into -t targets site packages for the current shell/venv
+             """)
 ]
 
 # decorators be parsed inside out which click handles, but no decorators on the shared options


### PR DESCRIPTION
added example to readme of site-packages target list generation in-line to the flag argument

I figured out a simpler way to specify site packages targets as shown below without having to save the output to an env var and pass it in:

```
artie@ArtieSonaDell:~$ source .venv/bin/activate
(.venv) artie@ArtieSonaDell:~$ jake ddt -t "`python -c "import site; print(site.getsitepackages())"`"
                   ___           ___           ___
       ___        /  /\         /  /\         /  /\
      /__/\      /  /::\       /  /:/        /  /::\
      \__\:\    /  /:/\:\     /  /:/        /  /:/\:\
  ___ /  /::\  /  /::\ \:\   /  /::\____   /  /::\ \:\
 /__/\  /:/\/ /__/:/\:\_\:\ /__/:/\:::::\ /__/:/\:\ \:\
 \  \:\/:/~~  \__\/  \:\/:/ \__\/~|:|~~~~ \  \:\ \:\_\/
  \  \::/          \__\::/     |  |:|      \  \:\ \:\
   \__\/           /  /:/      |  |:|       \  \:\_\/
                  /__/:/       |__|:|        \  \:\
                  \__\/         \__\|         \__\/


                /)                     /)
            _/_(/    _     _  __   _  (/_   _
     o   o  (__/ )__(/_   /_)_/ (_(_(_/(___(/_ o   o



Jake version: v0.2.70
Put your python deps in a chokehold.
🐍  Collecting Dependencies
🐍  Querying OSS Index
🐍  Auditing results from OSS Index

Non-Vulnerable Dependencies

[1/4] - pkg:pypi/setuptools@44.0.0?extension=tar.gz
[2/4] - pkg:pypi/pyyaml@5.4.1?extension=tar.gz
[3/4] - pkg:pypi/pkg-resources@0.0.0?extension=tar.gz
[4/4] - pkg:pypi/pip@20.0.2?extension=tar.gz

╔Summary═══════════════╦═══╗
║ Audited Dependencies ║ 4 ║
╠══════════════════════╬═══╣
║ Vulnerablities Found ║ 0 ║
╚══════════════════════╩═══╝
```

cc @bhamail / @DarthHater
