### PR TITLE
FIX: Enable non-zero exit code + correct logic in determining Nexus IQ policy warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@
 ![Python Version Support](https://img.shields.io/badge/python-3.6+-blue)
 ![PyPI Version](https://img.shields.io/pypi/v/jake?label=PyPI&logo=pypi)
 [![GitHub license](https://img.shields.io/github/license/sonatype-nexus-community/jake)](https://github.com/sonatype-nexus-community/jake/blob/main/LICENSE)
-[![GitHub issues](https://img.shields.io/github/issues/sonatype-nexus-community/jaken)](https://github.com/sonatype-nexus-community/jake/issues)
+[![GitHub issues](https://img.shields.io/github/issues/sonatype-nexus-community/jake)](https://github.com/sonatype-nexus-community/jake/issues)
 [![GitHub forks](https://img.shields.io/github/forks/sonatype-nexus-community/jake)](https://github.com/sonatype-nexus-community/jake/network)
-[![GitHub stars](https://img.shields.io/github/stars/sonatype-nexus-community/jaken)](https://github.com/sonatype-nexus-community/jake/stargazers)
+[![GitHub stars](https://img.shields.io/github/stars/sonatype-nexus-community/jake)](https://github.com/sonatype-nexus-community/jake/stargazers)
 
 ----
 
@@ -68,16 +68,21 @@ usage: jake [-h] [-v] [-X]  ...
 Put your Python dependencies in a chokehold
 
 optional arguments:
-  -h, --help     show this help message and exit
-  -v, --version  show which version of jake you are running
-  -X             enable debug output
+  -h, --help        show this help message and exit
+  -v, --version     show which version of jake you are running
+  -w, --warn-only   prevents exit with non-zero code when issues have been
+                    detected
+  -X                enable debug output
 
 Jake sub-commands:
 
-    iq           perform a scan backed by Nexus Lifecycle
-    ddt          perform a scan backed by OSS Index
-    sbom         generate a CycloneDX software-bill-of-materials (no vulnerabilities)
+    iq              perform a scan backed by Nexus Lifecycle
+    ddt             perform a scan backed by OSS Index
+    sbom            generate a CycloneDX software-bill-of-materials (no vulnerabilities)
 ```
+
+`jake` will exit with code `0` under normal operation and `1` if vulnerabilities are found (OssIndex) or Policy 
+Violations are detected (Nexus IQ), unless you pass the `-w` flag in which case `jake` will always exit with code `0`....
 
 ### Check for vulnerabilities using OSS Index
 

--- a/jake/app.py
+++ b/jake/app.py
@@ -62,7 +62,8 @@ class JakeCmd:
         # Determine primary command and then hand off to that Command handler
         if self._arguments.cmd:
             command = self._subcommands[self._arguments.cmd]
-            command.execute(arguments=self._arguments)
+            exit_code: int = command.execute(arguments=self._arguments)
+            exit(exit_code)
         else:
             self._arg_parser.print_help()
 
@@ -80,7 +81,9 @@ class JakeCmd:
         # Add global options
         self._arg_parser.add_argument('-v', '--version', help='show which version of jake you are running',
                                       action='version',
-                                      version='%{prog}s 1.0-dev')
+                                      version=f'jake {JakeCmd._get_jake_version()}')
+        self._arg_parser.add_argument('-w', '--warn-only', action='store_true', dest='warn_only',
+                                      help='prevents exit with non-zero code when issues have been detected')
         self._arg_parser.add_argument('-X', action='store_true', help='enable debug output', dest='debug_enabled')
 
         subparsers = self._arg_parser.add_subparsers(title='Jake sub-commands', dest='cmd', metavar='')

--- a/jake/command/__init__.py
+++ b/jake/command/__init__.py
@@ -25,7 +25,7 @@ class BaseCommand(ABC):
     _arguments: argparse.Namespace
 
     @abstractmethod
-    def handle_args(self):
+    def handle_args(self) -> int:
         pass
 
     def execute(self, arguments: argparse.Namespace):

--- a/jake/command/sbom.py
+++ b/jake/command/sbom.py
@@ -30,7 +30,7 @@ from . import BaseCommand
 
 class SbomCommand(BaseCommand):
 
-    def handle_args(self):
+    def handle_args(self) -> int:
         self._arguments.sbom_input_type
         bom = Bom.from_parser(self._get_parser())
 
@@ -50,6 +50,8 @@ class SbomCommand(BaseCommand):
         else:
             # Output to STDOUT
             print(output.output_as_string())
+
+        return 0
 
     def setup_argument_parser(self, subparsers: argparse._SubParsersAction):
         parser: argparse.ArgumentParser = subparsers.add_parser(


### PR DESCRIPTION
Signed-off-by: Paul Horton <phorton@sonatype.com>

This PR primarily contains an update to allow `jake` to exit with code `1` when either:\
- OSS Index has reported vulnerabilities
- Nexus IQ has reported policy violations (FAIL)

This new functionality can also be overridden by adding the `-w` or `--warn-only` flag.

In addition an un-reported bug with the handling of results from Nexus IQ was noted and squashed (bad logic).

It relates to the following issue #s:
* Fixes #65

cc @bhamail / @DarthHater
