### PR TITLE
fix: bump required version of cyclonedx-python-lib to help lax transitive dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -65,17 +65,19 @@ toml = ["toml"]
 
 [[package]]
 name = "cyclonedx-python-lib"
-version = "0.10.2"
+version = "0.12.0"
 description = "A library for producing CycloneDX SBOM (Software Bill of Materials) files."
 category = "main"
 optional = false
 python-versions = ">=3.6,<4.0"
 
 [package.dependencies]
-importlib-metadata = {version = ">=4.8.1,<5.0.0", markers = "python_version >= \"3.6\" and python_version < \"3.8\""}
-packageurl-python = ">=0.9.4,<0.10.0"
+importlib-metadata = {version = ">=3.4.0,<4.9", markers = "python_version >= \"3.6\" and python_version < \"3.8\""}
+packageurl-python = ">=0.3.0,<0.10"
 requirements_parser = ">=0.2.0,<0.3.0"
-toml = ">=0.10.2,<0.11.0"
+toml = ">=0.10.0,<0.11.0"
+types-setuptools = ">=57.0.0,<57.5"
+types-toml = ">=0.10.0,<0.11.0"
 typing-extensions = {version = ">=3.10.0,<4.0.0", markers = "python_version >= \"3.6\" and python_version < \"3.8\""}
 
 [[package]]
@@ -88,7 +90,7 @@ python-versions = ">=3.6, <3.7"
 
 [[package]]
 name = "distlib"
-version = "0.3.3"
+version = "0.3.4"
 description = "Distribution utilities"
 category = "dev"
 optional = false
@@ -341,7 +343,7 @@ python-versions = ">=2.6"
 
 [[package]]
 name = "terminaltables"
-version = "3.1.7"
+version = "3.1.10"
 description = "Generate simple tables in terminals from a nested list of strings."
 category = "main"
 optional = false
@@ -388,6 +390,22 @@ virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,
 [package.extras]
 docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-autoprogram (>=0.1.5)", "towncrier (>=18.5.0)"]
 testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "psutil (>=5.6.1)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)", "pytest-xdist (>=1.22.2)", "pathlib2 (>=2.3.3)"]
+
+[[package]]
+name = "types-setuptools"
+version = "57.4.4"
+description = "Typing stubs for setuptools"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "types-toml"
+version = "0.10.1"
+description = "Typing stubs for toml"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
@@ -458,7 +476,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "748fe8fb9c2f30a379ca09354bee8c79ca730ba2d9df518fa768c2e0325c6ac1"
+content-hash = "8d9d223a83f65d620cc83700fc4d54bfcd9374cab83c0e5908fd627bd0755de7"
 
 [metadata.files]
 "backports.entry-points-selectable" = [
@@ -536,16 +554,16 @@ coverage = [
     {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
 ]
 cyclonedx-python-lib = [
-    {file = "cyclonedx-python-lib-0.10.2.tar.gz", hash = "sha256:6f79742ca1728b9016ea272bbe58a60441848e6b4f9742918b8eb67ca987df3b"},
-    {file = "cyclonedx_python_lib-0.10.2-py3-none-any.whl", hash = "sha256:e0b2cd3e91c3d55746ce7175a05c23ea2f618158a407b7c9d166eef083a4ee04"},
+    {file = "cyclonedx-python-lib-0.12.0.tar.gz", hash = "sha256:d8a8620f2518af4519bf7874fb5639a20cf59dabd61aa3be495977135410b50a"},
+    {file = "cyclonedx_python_lib-0.12.0-py3-none-any.whl", hash = "sha256:83a051f90244dfbbbc04bbbca1931ae656f315d2e7254de0dd0de40f028f7e7d"},
 ]
 dataclasses = [
     {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
     {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
 ]
 distlib = [
-    {file = "distlib-0.3.3-py2.py3-none-any.whl", hash = "sha256:c8b54e8454e5bf6237cc84c20e8264c3e991e824ef27e8f1e81049867d861e31"},
-    {file = "distlib-0.3.3.zip", hash = "sha256:d982d0751ff6eaaab5e2ec8e691d949ee80eddf01a62eaa96ddb11531fe16b05"},
+    {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
+    {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
 ]
 filelock = [
     {file = "filelock-3.4.0-py3-none-any.whl", hash = "sha256:2e139a228bcf56dd8b2274a65174d005c4a6b68540ee0bdbb92c76f43f29f7e8"},
@@ -665,8 +683,8 @@ termcolor-whl = [
     {file = "termcolor_whl-1.1.2-py2.py3-none-any.whl", hash = "sha256:3e7eda7348bb90ddea2d7a2171df65ed4a37adf62574fbd5459198410fdba881"},
 ]
 terminaltables = [
-    {file = "terminaltables-3.1.7-py2.py3-none-any.whl", hash = "sha256:18ba14fdfbc6a6d7dcf65aa0871a5dbea81d7d324ecfad8dc8c2f94b3efb4f2e"},
-    {file = "terminaltables-3.1.7.tar.gz", hash = "sha256:5dab2f33927c0a020b8011c81b92830ff9fd4ba701657da5d7bfdc41048360a6"},
+    {file = "terminaltables-3.1.10-py2.py3-none-any.whl", hash = "sha256:e4fdc4179c9e4aab5f674d80f09d76fa436b96fdc698a8505e0a36bf0804a874"},
+    {file = "terminaltables-3.1.10.tar.gz", hash = "sha256:ba6eca5cb5ba02bba4c9f4f985af80c54ec3dccf94cfcd190154386255e47543"},
 ]
 tinydb = [
     {file = "tinydb-4.5.2-py3-none-any.whl", hash = "sha256:3c5e5c72c98db07e707be4e25f9e135a8a14b96938e4745b1b7187fec523ff58"},
@@ -679,6 +697,14 @@ toml = [
 tox = [
     {file = "tox-3.24.4-py2.py3-none-any.whl", hash = "sha256:5e274227a53dc9ef856767c21867377ba395992549f02ce55eb549f9fb9a8d10"},
     {file = "tox-3.24.4.tar.gz", hash = "sha256:c30b57fa2477f1fb7c36aa1d83292d5c2336cd0018119e1b1c17340e2c2708ca"},
+]
+types-setuptools = [
+    {file = "types-setuptools-57.4.4.tar.gz", hash = "sha256:a3cbcbf3f02142bb5d3b5c5f5918f453b8752362b96d58aba2a5cfa43ba6d209"},
+    {file = "types_setuptools-57.4.4-py3-none-any.whl", hash = "sha256:9fe4180548e5cbb44cc0d343a47e4dc1d6769c31e16447994788c28df169011f"},
+]
+types-toml = [
+    {file = "types-toml-0.10.1.tar.gz", hash = "sha256:5c1f8f8d57692397c8f902bf6b4d913a0952235db7db17d2908cc110e70610cb"},
+    {file = "types_toml-0.10.1-py3-none-any.whl", hash = "sha256:8cdfd2b7c89bed703158b042dd5cf04255dae77096db66f4a12ca0a93ccb07a5"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ tinydb = "^4.5.1"
 PyYAML = "^5.4.1"
 requests = "^2.26.0"
 terminaltables = "^3.1.7"
-cyclonedx-python-lib = "^0.10.2"
+cyclonedx-python-lib = "^0.12.0"
 polling2 = "^0.5.0"
 ossindex-lib = "^0.2.1"
 


### PR DESCRIPTION
Signed-off-by: Paul Horton <phorton@sonatype.com>

This is part of #73.

cc @bhamail / @DarthHater
