### PR TITLE
feat(pre-commit): add pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+-   id: scan
+    name: jake oss scan
+    description: runs a sonatype oss index-backed scan
+    entry: jake ddt
+    language: python
+    types_or: [python, pyi]
+    pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -267,6 +267,15 @@ Vulnerability Details for pkg:pypi/cryptography@2.2
 └──────────────────────┴───────────────────────┘
 ```
 
+A pre-commit hook is also available for use
+
+```Yaml
+  - repo: https://github.com/sonatype-nexus-community/jake
+    rev: "v1.2.4"
+    hooks:
+      - id: scan
+```
+
 ### Check for vulnerabilities using Sonatype Nexus Lifecycle
 
 Access Sonatype's proprietary vulnerability data using `jake`:


### PR DESCRIPTION
I've added a simple pre-commit hook to be used to launch an OSS-backed ddt scan

This pull request makes the following changes:
* Adds a pre-commit hook
* Documents a simple use of the hook

It relates to the following issue #s:
* Fixes #84 

cc @bhamail / @DarthHater
