### PR TITLE
fix: `bom-ref` will always now be populated for Component and Vulnerability

### DIFF
--- a/jake/command/oss.py
+++ b/jake/command/oss.py
@@ -24,8 +24,9 @@ from typing import List, Optional
 from cyclonedx.model import XsUri
 from cyclonedx.model.bom import Bom
 from cyclonedx.model.component import Component
-from cyclonedx.model.vulnerability import Vulnerability, VulnerabilityRating, VulnerabilityReference, \
-    VulnerabilityScoreSource, VulnerabilitySeverity, VulnerabilitySource
+from cyclonedx.model.impact_analysis import ImpactAnalysisAffectedStatus
+from cyclonedx.model.vulnerability import BomTarget, BomTargetVersionRange, Vulnerability, VulnerabilityRating, \
+    VulnerabilityReference, VulnerabilityScoreSource, VulnerabilitySeverity, VulnerabilitySource
 from cyclonedx.output import get_instance, OutputFormat, SchemaVersion
 from cyclonedx_py.parser.environment import EnvironmentParser
 from ossindex.model import OssIndexComponent
@@ -143,6 +144,17 @@ class OssCommand(BaseCommand):
                                 vulnerability.add_reference(VulnerabilityReference(
                                     source=VulnerabilitySource(url=XsUri(ext_ref_url))
                                 ))
+
+                        vulnerability.affects = [
+                            BomTarget(
+                                ref=component.bom_ref,
+                                versions=[
+                                    BomTargetVersionRange(
+                                        version=component.version, status=ImpactAnalysisAffectedStatus.AFFECTED
+                                    )
+                                ]
+                            )
+                        ]
 
                         component.add_vulnerability(vulnerability=vulnerability)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -71,18 +71,18 @@ toml = ["tomli"]
 
 [[package]]
 name = "cyclonedx-bom"
-version = "2.0.0"
+version = "2.0.1"
 description = "CycloneDX Software Bill of Materials (SBOM) generation utility"
 category = "main"
 optional = false
 python-versions = ">=3.6,<4.0"
 
 [package.dependencies]
-cyclonedx-python-lib = ">=1.0.0,<2.0.0"
+cyclonedx-python-lib = ">=1.3.0,<2.0.0"
 
 [[package]]
 name = "cyclonedx-python-lib"
-version = "1.1.1"
+version = "1.3.0"
 description = "A library for producing CycloneDX SBOM (Software Bill of Materials) files."
 category = "main"
 optional = false
@@ -305,7 +305,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "pyparsing"
-version = "3.0.6"
+version = "3.0.7"
 description = "Python parsing module"
 category = "dev"
 optional = false
@@ -494,7 +494,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "80f1ae518fa5ff364cbbf16ecf30625f42f7f0d79c42fa3b9b2ba545bac99fac"
+content-hash = "5a105db8059665d0b73d021f518e096931e4daf525c733d55b9b047ba495804b"
 
 [metadata.files]
 atomicwrites = [
@@ -571,12 +571,12 @@ coverage = [
     {file = "coverage-6.2.tar.gz", hash = "sha256:e2cad8093172b7d1595b4ad66f24270808658e11acf43a8f95b41276162eb5b8"},
 ]
 cyclonedx-bom = [
-    {file = "cyclonedx-bom-2.0.0.tar.gz", hash = "sha256:1f061a9c6c43573d4b5419fcad4d23ef4a609d86705b82c4cafcc6cd4468c734"},
-    {file = "cyclonedx_bom-2.0.0-py3-none-any.whl", hash = "sha256:36002ae01f3f0eddbd11c26099c46d528be39c0b50903a963cb99aeb789fc510"},
+    {file = "cyclonedx-bom-2.0.1.tar.gz", hash = "sha256:83ae46cd76b0a7137bb786c6696c2f2c55abe10872a815381a2e3c064b2a5d9e"},
+    {file = "cyclonedx_bom-2.0.1-py3-none-any.whl", hash = "sha256:57a932053118804f30d11b634b2205652d6100d671a62873ddea0a658435d47e"},
 ]
 cyclonedx-python-lib = [
-    {file = "cyclonedx-python-lib-1.1.1.tar.gz", hash = "sha256:03f810246ee45d8a8027e5f159c13d67632ae5a8e2e1d143b1bcc28b8b98b9eb"},
-    {file = "cyclonedx_python_lib-1.1.1-py3-none-any.whl", hash = "sha256:76e20b205c97b4824733fb55acb33977cd5fdb636e9977666703944d0a01df60"},
+    {file = "cyclonedx-python-lib-1.3.0.tar.gz", hash = "sha256:8793fcf6a4735835bda33cda461a9a60c63faf0a8f9c58fc1fc4312e8f307164"},
+    {file = "cyclonedx_python_lib-1.3.0-py3-none-any.whl", hash = "sha256:2b8b1250f6b22b4836bfb86b87381a228377e4d329d6d6d7488a2cdfbc073049"},
 ]
 dataclasses = [
     {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
@@ -659,8 +659,8 @@ pygments = [
     {file = "Pygments-2.11.2.tar.gz", hash = "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"},
 ]
 pyparsing = [
-    {file = "pyparsing-3.0.6-py3-none-any.whl", hash = "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4"},
-    {file = "pyparsing-3.0.6.tar.gz", hash = "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"},
+    {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},
+    {file = "pyparsing-3.0.7.tar.gz", hash = "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea"},
 ]
 pytest = [
     {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ jake = 'jake.app:main'
 
 [tool.poetry.dependencies]
 python = "^3.6.2"
-cyclonedx-bom = "^2.0.0"
+cyclonedx-bom = "^2.0.1"
 ossindex-lib = ">= 0.2.1"
 polling2 = ">= 0.5.0"
 pyfiglet = ">= 0.8.post1"


### PR DESCRIPTION
fix:`bom-ref` will always now be populated for Component and Vulnerability - bump of `cyclonedx-python-lib` resolves this

fix: complete `affects` for vulnerabilities received from OSS Index

Signed-off-by: Paul Horton <phorton@sonatype.com>

It relates to the following issue #s:
* Fixes #91 

cc @bhamail / @DarthHater
