### PR TITLE
fix: CWEs not passed as ints to CDX model

### DIFF
--- a/jake/command/oss.py
+++ b/jake/command/oss.py
@@ -134,7 +134,7 @@ class OssCommand(BaseCommand):
                             source=VulnerabilitySource(
                                 name='OSS Index', url=XsUri(oic_vulnerability.get_oss_index_reference_url())
                             ),
-                            cwes=[int(oic_vulnerability.get_cwe())] if oic_vulnerability.get_cwe() else None,
+                            cwes=[int(oic_vulnerability.get_cwe()[4:])] if oic_vulnerability.get_cwe() else None,
                             description=oic_vulnerability.get_title(),
                             detail=oic_vulnerability.get_description(),
                             ratings=ratings,


### PR DESCRIPTION
Signed-off-by: Paul Horton <phorton@sonatype.com>

This pull request makes the following changes:
* Correctly parse CWE references to `int` values as required by CDX model

It relates to the following issue #s:
* Fixes #95

cc @bhamail / @DarthHater
