### PR TITLE
fix: pin some upstream dependencies to prevent #112

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -30,7 +30,7 @@ python-versions = "*"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.10"
+version = "2.0.12"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
@@ -71,7 +71,7 @@ toml = ["tomli"]
 
 [[package]]
 name = "cyclonedx-bom"
-version = "2.0.1"
+version = "2.0.3"
 description = "CycloneDX Software Bill of Materials (SBOM) generation utility"
 category = "main"
 optional = false
@@ -208,14 +208,14 @@ tinydb = ">=4.5.1,<5.0.0"
 
 [[package]]
 name = "packageurl-python"
-version = "0.9.6"
+version = "0.9.8.1"
 description = "A purl aka. Package URL parser and builder"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-test = ["pytest", "isort"]
+test = ["isort", "pytest"]
 
 [[package]]
 name = "packaging"
@@ -356,7 +356,7 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 name = "rich"
-version = "11.0.0"
+version = "11.2.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 category = "main"
 optional = false
@@ -424,7 +424,7 @@ testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pytest (>=4.0.0)", "pytes
 
 [[package]]
 name = "types-setuptools"
-version = "57.4.7"
+version = "57.4.9"
 description = "Typing stubs for setuptools"
 category = "main"
 optional = false
@@ -432,7 +432,7 @@ python-versions = "*"
 
 [[package]]
 name = "types-toml"
-version = "0.10.3"
+version = "0.10.4"
 description = "Typing stubs for toml"
 category = "main"
 optional = false
@@ -461,7 +461,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.13.0"
+version = "20.13.1"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -494,7 +494,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "5a105db8059665d0b73d021f518e096931e4daf525c733d55b9b047ba495804b"
+content-hash = "01aa1f5e120726f4d5dbf9bb067a8aebdce2ffbb081c408cd75ec07949ddb3fe"
 
 [metadata.files]
 atomicwrites = [
@@ -510,8 +510,8 @@ certifi = [
     {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.10.tar.gz", hash = "sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd"},
-    {file = "charset_normalizer-2.0.10-py3-none-any.whl", hash = "sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455"},
+    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
+    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
@@ -571,8 +571,8 @@ coverage = [
     {file = "coverage-6.2.tar.gz", hash = "sha256:e2cad8093172b7d1595b4ad66f24270808658e11acf43a8f95b41276162eb5b8"},
 ]
 cyclonedx-bom = [
-    {file = "cyclonedx-bom-2.0.1.tar.gz", hash = "sha256:83ae46cd76b0a7137bb786c6696c2f2c55abe10872a815381a2e3c064b2a5d9e"},
-    {file = "cyclonedx_bom-2.0.1-py3-none-any.whl", hash = "sha256:57a932053118804f30d11b634b2205652d6100d671a62873ddea0a658435d47e"},
+    {file = "cyclonedx-bom-2.0.3.tar.gz", hash = "sha256:37485913ced9be02b0f0eb01060c7b4ac68e9fcc1f414ad3150d06aaad26ce03"},
+    {file = "cyclonedx_bom-2.0.3-py3-none-any.whl", hash = "sha256:a84880a2c4760b0dc18469327707644e454d0464e5aa16cac593f656c2ce3bf2"},
 ]
 cyclonedx-python-lib = [
     {file = "cyclonedx-python-lib-1.3.0.tar.gz", hash = "sha256:8793fcf6a4735835bda33cda461a9a60c63faf0a8f9c58fc1fc4312e8f307164"},
@@ -619,8 +619,8 @@ ossindex-lib = [
     {file = "ossindex_lib-0.2.1-py3-none-any.whl", hash = "sha256:72a888d82272bab3eac050f2953fc1207133bb30c64b0a9b393a2f334d19d12a"},
 ]
 packageurl-python = [
-    {file = "packageurl-python-0.9.6.tar.gz", hash = "sha256:c01fbaf62ad2eb791e97158d1f30349e830bee2dd3e9503a87f6c3ffae8d1cf0"},
-    {file = "packageurl_python-0.9.6-py3-none-any.whl", hash = "sha256:676dcb8278721df952e2444bfcd8d7bf3518894498050f0c6a5faddbe0860cd0"},
+    {file = "packageurl-python-0.9.8.1.tar.gz", hash = "sha256:675e0ec8058fa0837a0405047178bdea6a7d0b46966983fa79e1c0a1afab1c9e"},
+    {file = "packageurl_python-0.9.8.1-py3-none-any.whl", hash = "sha256:3545c89efb19ef26246c69201c748e60e4395a055b83347760064853b60eb9d7"},
 ]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
@@ -671,8 +671,8 @@ requests = [
     {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
 ]
 rich = [
-    {file = "rich-11.0.0-py3-none-any.whl", hash = "sha256:d7a8086aa1fa7e817e3bba544eee4fd82047ef59036313147759c11475f0dafd"},
-    {file = "rich-11.0.0.tar.gz", hash = "sha256:c32a8340b21c75931f157466fefe81ae10b92c36a5ea34524dff3767238774a4"},
+    {file = "rich-11.2.0-py3-none-any.whl", hash = "sha256:d5f49ad91fb343efcae45a2b2df04a9755e863e50413623ab8c9e74f05aee52b"},
+    {file = "rich-11.2.0.tar.gz", hash = "sha256:1a6266a5738115017bb64a66c59c717e7aa047b3ae49a011ede4abdeffc6536e"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -691,12 +691,12 @@ tox = [
     {file = "tox-3.24.5.tar.gz", hash = "sha256:67e0e32c90e278251fea45b696d0fef3879089ccbe979b0c556d35d5a70e2993"},
 ]
 types-setuptools = [
-    {file = "types-setuptools-57.4.7.tar.gz", hash = "sha256:9677d969b00ec1c14552f5be2b2b47a6fbea4d0ed4de0fdcee18abdaa0cc9267"},
-    {file = "types_setuptools-57.4.7-py3-none-any.whl", hash = "sha256:ffda504687ea02d4b7751c0d1df517fbbcdc276836d90849e4f1a5f1ccd79f01"},
+    {file = "types-setuptools-57.4.9.tar.gz", hash = "sha256:536ef74744f8e1e4be4fc719887f886e74e4cf3c792b4a06984320be4df450b5"},
+    {file = "types_setuptools-57.4.9-py3-none-any.whl", hash = "sha256:948dc6863373750e2cd0b223a84f1fb608414cde5e55cf38ea657b93aeb411d2"},
 ]
 types-toml = [
-    {file = "types-toml-0.10.3.tar.gz", hash = "sha256:215a7a79198651ec5bdfd66193c1e71eb681a42f3ef7226c9af3123ced62564a"},
-    {file = "types_toml-0.10.3-py3-none-any.whl", hash = "sha256:988457744d9774d194e3539388772e3a685d8057b7c4a89407afeb0a6cbd1b14"},
+    {file = "types-toml-0.10.4.tar.gz", hash = "sha256:9340e7c1587715581bb13905b3af30b79fe68afaccfca377665d5e63b694129a"},
+    {file = "types_toml-0.10.4-py3-none-any.whl", hash = "sha256:4a9ffd47bbcec49c6fde6351a889b2c1bd3c0ef309fa0eed60dc28e58c8b9ea6"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},
@@ -708,8 +708,8 @@ urllib3 = [
     {file = "urllib3-1.26.8.tar.gz", hash = "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.13.0-py2.py3-none-any.whl", hash = "sha256:339f16c4a86b44240ba7223d0f93a7887c3ca04b5f9c8129da7958447d079b09"},
-    {file = "virtualenv-20.13.0.tar.gz", hash = "sha256:d8458cf8d59d0ea495ad9b34c2599487f8a7772d796f9910858376d1600dd2dd"},
+    {file = "virtualenv-20.13.1-py2.py3-none-any.whl", hash = "sha256:45e1d053cad4cd453181ae877c4ffc053546ae99e7dd049b9ff1d9be7491abf7"},
+    {file = "virtualenv-20.13.1.tar.gz", hash = "sha256:e0621bcbf4160e4e1030f05065c8834b4e93f4fcc223255db2a823440aca9c14"},
 ]
 zipp = [
     {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ jake = 'jake.app:main'
 
 [tool.poetry.dependencies]
 python = "^3.6.2"
-cyclonedx-bom = "^2.0.1"
-ossindex-lib = ">= 0.2.1"
+cyclonedx-bom = ">= 2.0.1, < 3.0.0"
+ossindex-lib = ">= 0.2.1, < 1.0.0"
 polling2 = ">= 0.5.0"
 pyfiglet = ">= 0.8.post1"
 requests = "^>= 2.25.1"


### PR DESCRIPTION
Signed-off-by: Paul Horton <phorton@sonatype.com>

Some upstream dependencies have release candidates (RCs) for next major versions which break the current version of `jake`.

This PR looks to prevent these newer versions from being used with `jake`.

It relates to the following issue #s:
* Fixes #112 

cc @bhamail / @DarthHater
