### PR TITLE
prevent manual_release job on non-main branches. partial fix for #108

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,9 @@ workflows:
     jobs:
       - manual_release:
           type: approval
+          filters:
+            branches:
+              only: main
       - release_and_pypi_publish:
           requires:
             - manual_release


### PR DESCRIPTION
Try a filter to prevent `manual_release` job from running on feature branches

cc @bhamail / @DarthHater
