### PR TITLE
feat: Support for all input formats when running jake ddt or jake iq

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,11 +71,11 @@ jobs:
       - run:
           command: |
             poetry run tox -e py<< parameters.python_version >>
-      - run:
-          name: "Run Jake on Jake"
-          command: |
-            poetry install --no-dev
-            poetry run jake ddt --whitelist jake-whitelist.json
+#      - run:
+#          name: "Run Jake on Jake"
+#          command: |
+#            poetry install --no-dev
+#            poetry run jake ddt --whitelist jake-whitelist.json
 
   coding_standards:
     executor: python310

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ commands:
       - run: |
           python -m ensurepip --default-pip
           pip install --upgrade pip
-          pip install poetry==1.2.2
+          pip install poetry==1.1.15
 
 executors:
   python310:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ commands:
       - run: |
           python -m ensurepip --default-pip
           pip install --upgrade pip
-          pip install poetry==1.1.11
+          pip install poetry==1.2.2
 
 executors:
   python310:
@@ -71,11 +71,11 @@ jobs:
       - run:
           command: |
             poetry run tox -e py<< parameters.python_version >>
-#      - run:
-#          name: "Run Jake on Jake"
-#          command: |
-#            poetry install --no-dev
-#            poetry run jake ddt
+      - run:
+          name: "Run Jake on Jake"
+          command: |
+            poetry install --no-dev
+            poetry run jake ddt --whitelist jake-whitelist.json
 
   coding_standards:
     executor: python310

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ optional arguments:
 So passing parameters that suit your Nexus Lifecycle environment you can get a report:
 
 ```
-> jake iq -s https://my-nexus-lifecyle -i APP_ID -u USERNAME -p PASSWORD
+> jake iq -s https://my-nexus-lifecyle -a APP_ID -u USERNAME -p PASSWORD
 
                    ___           ___           ___     
        ___        /  /\         /  /\         /  /\    

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ optional arguments:
                         will then fall back to looking for standard files in
                         the current directory that relate to the type of input
                         indicated by the -t flag.
-  -it TYPE, --type TYPE, --input-type TYPE
+  -t TYPE, --type TYPE, -it TYPE, --input-type TYPE
                         how jake should find the packages from which to
                         generate your SBOM.ENV = Read from the current Python
                         Environment; CONDA = Read output from `conda list
@@ -154,7 +154,7 @@ optional arguments:
                         will then fall back to looking for standard files in
                         the current directory that relate to the type of input
                         indicated by the -t flag.
-  -it TYPE, --type TYPE, --input-type TYPE
+  -t TYPE, --type TYPE, -it TYPE, --input-type TYPE
                         how jake should find the packages from which to
                         generate your SBOM.ENV = Read from the current Python
                         Environment; CONDA = Read output from `conda list
@@ -318,7 +318,7 @@ Access Sonatype's proprietary vulnerability data using `jake`:
 ```
 > jake iq --help
 
-usage: jake iq [-h] -s https://localhost:8070 -i APP_ID -u USER_ID -p PASSWORD [-t STAGE]
+usage: jake iq [-h] -s https://localhost:8070 -i APP_ID -u USER_ID -p PASSWORD [-st STAGE]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -329,7 +329,7 @@ optional arguments:
                         will then fall back to looking for standard files in
                         the current directory that relate to the type of input
                         indicated by the -t flag.
-  -it TYPE, --type TYPE, --input-type TYPE
+  -t TYPE, --type TYPE, -it TYPE, --input-type TYPE
                         how jake should find the packages from which to
                         generate your SBOM.ENV = Read from the current Python
                         Environment; CONDA = Read output from `conda list
@@ -345,7 +345,7 @@ optional arguments:
                         Username for authentication to Nexus Lifecycle
   -p PASSWORD, --password PASSWORD
                         Password for authentication to Nexus Lifecycle
-  -t STAGE, --stage STAGE
+  -st STAGE, --stage STAGE
                         The stage for the report
 ```
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ optional arguments:
                         will then fall back to looking for standard files in
                         the current directory that relate to the type of input
                         indicated by the -t flag.
-  -t TYPE, --type TYPE, -it TYPE, --input-type TYPE
+  -it TYPE, --type TYPE, --input-type TYPE
                         how jake should find the packages from which to
                         generate your SBOM.ENV = Read from the current Python
                         Environment; CONDA = Read output from `conda list
@@ -147,6 +147,21 @@ usage: jake ddt [-h] [--clear-cache] [-o PATH/TO/FILE] [--output-format {xml,jso
 
 optional arguments:
   -h, --help            show this help message and exit
+  -i FILE_PATH, --input FILE_PATH
+                        Where to get input data from. If a path to a file is
+                        not specified directly here,then we will attempt to
+                        read data from STDIN. If there is no data on STDIN, we
+                        will then fall back to looking for standard files in
+                        the current directory that relate to the type of input
+                        indicated by the -t flag.
+  -it TYPE, --type TYPE, --input-type TYPE
+                        how jake should find the packages from which to
+                        generate your SBOM.ENV = Read from the current Python
+                        Environment; CONDA = Read output from `conda list
+                        --explicit`; CONDA_JSON = Read output from `conda list
+                        --json`; PIP = read from a requirements.txt; PIPENV =
+                        read from Pipfile.lock; POETRY = read from a
+                        poetry.lock. (Default = ENV)
   --clear-cache         Clears any local cached OSS Index data prior to execution
   -o PATH/TO/FILE, --output-file PATH/TO/FILE
                         Specify a file to output the SBOM to. If not specified the report will be output to the console. STDOUT is not supported.
@@ -307,9 +322,24 @@ usage: jake iq [-h] -s https://localhost:8070 -i APP_ID -u USER_ID -p PASSWORD [
 
 optional arguments:
   -h, --help            show this help message and exit
+  -i FILE_PATH, --input FILE_PATH
+                        Where to get input data from. If a path to a file is
+                        not specified directly here,then we will attempt to
+                        read data from STDIN. If there is no data on STDIN, we
+                        will then fall back to looking for standard files in
+                        the current directory that relate to the type of input
+                        indicated by the -t flag.
+  -it TYPE, --type TYPE, --input-type TYPE
+                        how jake should find the packages from which to
+                        generate your SBOM.ENV = Read from the current Python
+                        Environment; CONDA = Read output from `conda list
+                        --explicit`; CONDA_JSON = Read output from `conda list
+                        --json`; PIP = read from a requirements.txt; PIPENV =
+                        read from Pipfile.lock; POETRY = read from a
+                        poetry.lock. (Default = ENV)
   -s https://localhost:8070, --server-url https://localhost:8070
                         Full http(s):// URL to your Nexus Lifecycle server
-  -i APP_ID, --application-id APP_ID
+  -a APP_ID, --application-id APP_ID
                         Public Application ID in Nexus Lifecycle
   -u USER_ID, --username USER_ID
                         Username for authentication to Nexus Lifecycle

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ optional arguments:
                         poetry.lock. (Default = ENV)
   -s https://localhost:8070, --server-url https://localhost:8070
                         Full http(s):// URL to your Nexus Lifecycle server
-  -a APP_ID, --application-id APP_ID
+  -i APP_ID, --application-id APP_ID
                         Public Application ID in Nexus Lifecycle
   -u USER_ID, --username USER_ID
                         Username for authentication to Nexus Lifecycle
@@ -352,7 +352,7 @@ optional arguments:
 So passing parameters that suit your Nexus Lifecycle environment you can get a report:
 
 ```
-> jake iq -s https://my-nexus-lifecyle -a APP_ID -u USERNAME -p PASSWORD
+> jake iq -s https://my-nexus-lifecyle -i APP_ID -u USERNAME -p PASSWORD
 
                    ___           ___           ___     
        ___        /  /\         /  /\         /  /\    

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ usage: jake sbom [-h] [-f FILE_PATH] [-t TYPE] [-o PATH/TO/FILE]
 
 optional arguments:
   -h, --help            show this help message and exit
-  -i FILE_PATH, --input FILE_PATH
+  -f FILE_PATH, --input FILE_PATH
                         Where to get input data from. If a path to a file is
                         not specified directly here,then we will attempt to
                         read data from STDIN. If there is no data on STDIN, we
@@ -143,11 +143,14 @@ Optionally, it can create a CycloneDX software bill-of-materials at the same tim
 ```
 > jake ddt --help
 
-usage: jake ddt [-h] [--clear-cache] [-o PATH/TO/FILE] [--output-format {xml,json}] [--schema-version {1.2,1.1,1.0,1.3}]
+usage: jake ddt [-h] [-f FILE_PATH] [-t TYPE] [--clear-cache] [-o PATH/TO/FILE] 
+                   [--output-format {xml,json}]
+                   [--schema-version {1.2,1.1,1.0,1.3}]
+                   [--whitelist OSS_WHITELIST_JSON_FILE]
 
 optional arguments:
   -h, --help            show this help message and exit
-  -i FILE_PATH, --input FILE_PATH
+  -f FILE_PATH, --input-file FILE_PATH
                         Where to get input data from. If a path to a file is
                         not specified directly here,then we will attempt to
                         read data from STDIN. If there is no data on STDIN, we
@@ -169,6 +172,8 @@ optional arguments:
                         SBOM output format (default = xml)
   --schema-version {1.2,1.1,1.0,1.3}
                         CycloneDX schema version to use (default = 1.3)
+  --whitelist OSS_WHITELIST_JSON_FILE
+                        Set path to whitelist json file
 ```
 
 So you can quickly get a report by running:
@@ -282,6 +287,19 @@ Vulnerability Details for pkg:pypi/cryptography@2.2
 └──────────────────────┴───────────────────────┘
 ```
 
+Check out these examples using STDIN:
+```
+conda list --explicit --md5 | jake ddt -t CONDA
+conda list --json | jake ddt -t CONDA_JSON
+cat /path/to/Pipfile.lock | python -m jake.app ddt -t PIPENV
+```
+
+Check out these examples specifying a manifest:
+```
+jake ddt -t PIP -i /path/to/requirements.txt
+jake ddt -t PIPENV -i /path/to/Pipfile.lock
+```
+
 A pre-commit hook is also available for use
 
 ```Yaml
@@ -318,11 +336,11 @@ Access Sonatype's proprietary vulnerability data using `jake`:
 ```
 > jake iq --help
 
-usage: jake iq [-h] -s https://localhost:8070 -i APP_ID -u USER_ID -p PASSWORD [-st STAGE]
+usage: jake iq [-h] [-f FILE_PATH] [-t TYPE] -s https://localhost:8070 -i APP_ID -u USER_ID -p PASSWORD [-st STAGE]
 
 optional arguments:
   -h, --help            show this help message and exit
-  -i FILE_PATH, --input FILE_PATH
+  -f FILE_PATH, --input-file FILE_PATH
                         Where to get input data from. If a path to a file is
                         not specified directly here,then we will attempt to
                         read data from STDIN. If there is no data on STDIN, we
@@ -427,4 +445,3 @@ community (read: you!)
 * DO file issues here on GitHub, so that the community can pitch in
 
 Phew, that was easier than I thought. Last but not least of all - have fun!
-

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ you.
 ```
 > jake sbom --help
 
-usage: jake sbom [-h] [-i FILE_PATH] [-t TYPE] [-o PATH/TO/FILE]
+usage: jake sbom [-h] [-f FILE_PATH] [-t TYPE] [-o PATH/TO/FILE]
                    [--output-format {json,xml}]
                    [--schema-version {1.0,1.1,1.2,1.3}]
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -64,7 +64,7 @@ you.
 
     optional arguments:
       -h, --help            show this help message and exit
-      -f FILE_PATH, --input FILE_PATH
+      -f FILE_PATH, --input-file FILE_PATH
                             Where to get input data from. If a path to a file is
                             not specified directly here,then we will attempt to
                             read data from STDIN. If there is no data on STDIN, we
@@ -260,7 +260,7 @@ Check out these examples specifying a manifest:
 
 .. code-block::
 
-    jake ddr -t PIP -f /path/to/requirements.txt
+    jake ddt -t PIP -f /path/to/requirements.txt
     jake ddt -t PIPENV -f /path/to/Pipfile.lock
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -259,7 +259,7 @@ Access Sonatype's proprietary vulnerability data using ``jake``:
 
     > jake iq --help
 
-    usage: jake iq [-h] -s https://localhost:8070 -i APP_ID -u USER_ID -p PASSWORD [-t STAGE]
+    usage: jake iq [-h] -s https://localhost:8070 -i APP_ID -u USER_ID -p PASSWORD [-st STAGE]
 
     optional arguments:
       -h, --help            show this help message and exit
@@ -271,7 +271,7 @@ Access Sonatype's proprietary vulnerability data using ``jake``:
                             Username for authentication to Nexus Lifecycle
       -p PASSWORD, --password PASSWORD
                             Password for authentication to Nexus Lifecycle
-      -t STAGE, --stage STAGE
+      -st STAGE, --stage STAGE
                             The stage for the report
 
 So passing parameters that suit your Nexus Lifecycle environment you can get a report:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -58,13 +58,13 @@ you.
 
     > jake sbom --help
 
-    usage: jake sbom [-h] [-i FILE_PATH] [-t TYPE] [-o PATH/TO/FILE]
+    usage: jake sbom [-h] [-f FILE_PATH] [-t TYPE] [-o PATH/TO/FILE]
                        [--output-format {json,xml}]
                        [--schema-version {1.0,1.1,1.2,1.3}]
 
     optional arguments:
       -h, --help            show this help message and exit
-      -i FILE_PATH, --input FILE_PATH
+      -f FILE_PATH, --input FILE_PATH
                             Where to get input data from. If a path to a file is
                             not specified directly here,then we will attempt to
                             read data from STDIN. If there is no data on STDIN, we
@@ -99,8 +99,8 @@ Check out these examples specifying a manifest:
 
 .. code-block::
 
-    jake sbom -t PIP -i /path/to/requirements.txt
-    jake sbom -t PIPENV -i /path/to/Pipfile.lock
+    jake sbom -t PIP -f /path/to/requirements.txt
+    jake sbom -t PIPENV -f /path/to/Pipfile.lock
 
 
 Check for vulnerabilities using OSS Index
@@ -113,17 +113,25 @@ you.
 
     > jake ddt --help
 
-    usage: jake ddt [-h] [--clear-cache] [-o PATH/TO/FILE] [--output-format {xml,json}] [--schema-version {1.2,1.1,1.0,1.3}]
+    usage: jake ddt [-h] [-f FILE_PATH] [-t TYPE] [--clear-cache] [-o PATH/TO/FILE] [--output-format {json,xml}] [--schema-version {1.2,1.3,1.4,1.1,1.0}] [--whitelist OSS_WHITELIST_JSON_FILE]
 
-    optional arguments:
+    options:
       -h, --help            show this help message and exit
+      -f FILE_PATH, --input-file FILE_PATH
+                            Where to get input data from. If a path to a file is not specified directly here,then we will attempt to read data from STDIN. If there is no data on STDIN, we will then fall back to looking for standard
+                            files in the current directory that relate to the type of input indicated by the -t flag.
+      -t TYPE, -it TYPE, --type TYPE, --input-type TYPE
+                            how jake should find the packages from which to generate your SBOM.ENV = Read from the current Python Environment; CONDA = Read output from `conda list --explicit`; CONDA_JSON = Read output from `conda list
+                            --json`; PIP = read from a requirements.txt; PIPENV = read from Pipfile.lock; POETRY = read from a poetry.lock. (Default = ENV)
       --clear-cache         Clears any local cached OSS Index data prior to execution
       -o PATH/TO/FILE, --output-file PATH/TO/FILE
                             Specify a file to output the SBOM to. If not specified the report will be output to the console. STDOUT is not supported.
-      --output-format {xml,json}
+      --output-format {json,xml}
                             SBOM output format (default = xml)
-      --schema-version {1.2,1.1,1.0,1.3}
-                            CycloneDX schema version to use (default = 1.3)
+      --schema-version {1.2,1.3,1.4,1.1,1.0}
+                            CycloneDX schema version to use (default = 1.4)
+      --whitelist OSS_WHITELIST_JSON_FILE
+                            Set path to whitelist json file
 
 So you can quickly get a report by running:
 
@@ -150,7 +158,7 @@ So you can quickly get a report by running:
 
 
 
-    Jake Version: 1.1.0
+    Jake Version: 2.1.1
     Put your Python dependencies in a chokehold.
 
     🐍 Collected 42 packages from your environment (0:00:00.10)
@@ -187,12 +195,13 @@ This is what ``jake`` will output if any bad things are found:
 
 
 
-    Jake Version: 1.1.5
+    Jake Version: 2.1.1
     Put your Python dependencies in a chokehold
 
-    🐍 Collected 69 packages from your environment                       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% -:--:--
+    🐍 Collected 69 packages from your python environment                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% -:--:--
     🐍 Successfully queried OSS Index for package and vulnerability info ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% -:--:--
     🐍 Sane number of results from OSS Index                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% -:--:--
+    🐍 Munching & crunching data...                                      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% -:--:--
 
     [59/69] - pkg:pypi/cryptography@2.2 [VULNERABLE]
     Vulnerability Details for pkg:pypi/cryptography@2.2
@@ -238,6 +247,23 @@ This is what ``jake`` will output if any bad things are found:
     └──────────────────────┴───────────────────────┘
 
 
+Check out these examples using STDIN:
+
+.. code-block::
+
+    conda list --explicit --md5 | jake ddt -t CONDA
+    conda list --json | jake ddt -t CONDA_JSON
+    cat /path/to/Pipfile.lock | jake ddt -t PIPENV
+
+
+Check out these examples specifying a manifest:
+
+.. code-block::
+
+    jake ddr -t PIP -f /path/to/requirements.txt
+    jake ddt -t PIPENV -f /path/to/Pipfile.lock
+
+
 Pre-commit Hook
 ~~~~~~~~~~~~~~~
 
@@ -259,13 +285,19 @@ Access Sonatype's proprietary vulnerability data using ``jake``:
 
     > jake iq --help
 
-    usage: jake iq [-h] -s https://localhost:8070 -a APP_ID -u USER_ID -p PASSWORD [-st STAGE]
+    usage: jake iq [-h] [-f FILE_PATH] [-t TYPE] -s https://localhost:8070 -i APP_ID -u USER_ID -p PASSWORD [-st STAGE]
 
-    optional arguments:
+    options:
       -h, --help            show this help message and exit
+      -f FILE_PATH, --input-file FILE_PATH
+                            Where to get input data from. If a path to a file is not specified directly here,then we will attempt to read data from STDIN. If there is no data on STDIN, we will then fall back to looking for standard
+                            files in the current directory that relate to the type of input indicated by the -t flag.
+      -t TYPE, -it TYPE, --type TYPE, --input-type TYPE
+                            how jake should find the packages from which to generate your SBOM.ENV = Read from the current Python Environment; CONDA = Read output from `conda list --explicit`; CONDA_JSON = Read output from `conda list
+                            --json`; PIP = read from a requirements.txt; PIPENV = read from Pipfile.lock; POETRY = read from a poetry.lock. (Default = ENV)
       -s https://localhost:8070, --server-url https://localhost:8070
                             Full http(s):// URL to your Nexus Lifecycle server
-      -a APP_ID, --application-id APP_ID
+      -i APP_ID, --application-id APP_ID
                             Public Application ID in Nexus Lifecycle
       -u USER_ID, --username USER_ID
                             Username for authentication to Nexus Lifecycle
@@ -278,7 +310,7 @@ So passing parameters that suit your Nexus Lifecycle environment you can get a r
 
 .. code-block::
 
-    > jake iq -s https://my-nexus-lifecyle -a APP_ID -u USERNAME -p PASSWORD
+    > jake iq -s https://my-nexus-lifecyle -i APP_ID -u USERNAME -p PASSWORD
 
                        ___           ___           ___
            ___        /  /\         /  /\         /  /\
@@ -299,7 +331,7 @@ So passing parameters that suit your Nexus Lifecycle environment you can get a r
 
 
 
-    Jake Version: 1.0.1
+    Jake Version: 2.1.1
     Put your Python dependencies in a chokehold
 
     🐍 IQ Server at https://my-nexus-lifecyle is up and accessible (0:00:00.14)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -259,13 +259,13 @@ Access Sonatype's proprietary vulnerability data using ``jake``:
 
     > jake iq --help
 
-    usage: jake iq [-h] -s https://localhost:8070 -i APP_ID -u USER_ID -p PASSWORD [-st STAGE]
+    usage: jake iq [-h] -s https://localhost:8070 -a APP_ID -u USER_ID -p PASSWORD [-st STAGE]
 
     optional arguments:
       -h, --help            show this help message and exit
       -s https://localhost:8070, --server-url https://localhost:8070
                             Full http(s):// URL to your Nexus Lifecycle server
-      -i APP_ID, --application-id APP_ID
+      -a APP_ID, --application-id APP_ID
                             Public Application ID in Nexus Lifecycle
       -u USER_ID, --username USER_ID
                             Username for authentication to Nexus Lifecycle
@@ -278,7 +278,7 @@ So passing parameters that suit your Nexus Lifecycle environment you can get a r
 
 .. code-block::
 
-    > jake iq -s https://my-nexus-lifecyle -i APP_ID -u USERNAME -p PASSWORD
+    > jake iq -s https://my-nexus-lifecyle -a APP_ID -u USERNAME -p PASSWORD
 
                        ___           ___           ___
            ___        /  /\         /  /\         /  /\

--- a/jake/command/iq.py
+++ b/jake/command/iq.py
@@ -273,5 +273,5 @@ class IqCommand(BaseCommand):
         arg_parser.add_argument('-p', '--password', help='Password for authentication to Nexus Lifecycle',
                                 metavar='PASSWORD', required=True, dest='iq_password')
 
-        arg_parser.add_argument('-t', '--stage', help='The stage for the report',
+        arg_parser.add_argument('-st', '--stage', help='The stage for the report',
                                 metavar='STAGE', required=False, dest='iq_scan_stage', default='source')

--- a/jake/command/iq.py
+++ b/jake/command/iq.py
@@ -264,7 +264,7 @@ class IqCommand(BaseCommand):
         arg_parser.add_argument('-s', '--server-url', help='Full http(s):// URL to your Nexus Lifecycle server',
                                 metavar='https://localhost:8070', required=True, dest='iq_server_url')
 
-        arg_parser.add_argument('-a', '--application-id', help='Public Application ID in Nexus Lifecycle',
+        arg_parser.add_argument('-i', '--application-id', help='Public Application ID in Nexus Lifecycle',
                                 metavar='APP_ID', required=True, dest='iq_application_id')
 
         arg_parser.add_argument('-u', '--username', help='Username for authentication to Nexus Lifecycle',

--- a/jake/command/parser_selector.py
+++ b/jake/command/parser_selector.py
@@ -1,0 +1,89 @@
+import sys
+from argparse import ArgumentParser
+from argparse import FileType
+from typing import Optional
+from typing import TextIO
+
+from cyclonedx.parser import BaseParser
+from cyclonedx_py.parser.conda import CondaListExplicitParser
+from cyclonedx_py.parser.conda import CondaListJsonParser
+from cyclonedx_py.parser.environment import EnvironmentParser
+from cyclonedx_py.parser.pipenv import PipEnvFileParser
+from cyclonedx_py.parser.pipenv import PipEnvParser
+from cyclonedx_py.parser.poetry import PoetryFileParser
+from cyclonedx_py.parser.poetry import PoetryParser
+from cyclonedx_py.parser.requirements import RequirementsFileParser
+from cyclonedx_py.parser.requirements import RequirementsParser
+
+
+def get_parser(input_type: str, input_data_fh: Optional[TextIO]) -> BaseParser:
+    if input_type == 'ENV':
+        return EnvironmentParser()
+
+    # All other input types require INPUT - let's grab it now if provided via STDIN or supplied FILE
+    if input_data_fh:
+        with input_data_fh:
+            input_data = input_data_fh.read()
+            input_data_fh.close()
+
+        if input_type == 'CONDA':
+            return CondaListExplicitParser(conda_data=input_data)
+
+        if input_type == 'CONDA_JSON':
+            return CondaListJsonParser(conda_data=input_data)
+
+        if input_type == 'PIP':
+            return RequirementsParser(requirements_content=input_data)
+
+        if input_type == 'PIPENV':
+            return PipEnvParser(pipenv_contents=input_data)
+
+        if input_type == 'POETRY':
+            return PoetryParser(poetry_lock_contents=input_data)
+
+    else:
+        # No data available on STDIN or the supplied FILE, so we'll try standard filenames in the current directory
+        if input_type == 'PIP':
+            return RequirementsFileParser(requirements_file='requirements.txt')
+
+        if input_type == 'PIPENV':
+            return PipEnvFileParser(pipenv_lock_filename='Pipfile.lock')
+
+        if input_type == 'POETRY':
+            return PoetryFileParser(poetry_lock_filename='poetry.lock')
+
+    raise NotImplementedError
+
+
+def add_parser_selector_arguments(arg_parser: ArgumentParser) -> None:
+    arg_parser.add_argument(
+        '-i',
+        '--input',
+        action='store',
+        metavar='FILE_PATH',
+        type=FileType('r'),
+        default=(None if sys.stdin.isatty() else sys.stdin),
+        help='Where to get input data from. If a path to a file is not specified directly here,'
+             'then we will attempt to read data from STDIN. If there is no data on STDIN, we '
+             'will then fall back to looking for standard files in the current directory that '
+             'relate to the type of input indicated by the -t flag.',
+        dest='sbom_input_source',
+        required=False
+    )
+    arg_parser.add_argument(
+        '-it',
+        '--type',
+        '--input-type',
+        help='how jake should find the packages from which to generate your SBOM.'
+             'ENV = Read from the current Python Environment; '
+             'CONDA = Read output from `conda list --explicit`; '
+             'CONDA_JSON = Read output from `conda list --json`; '
+             'PIP = read from a requirements.txt; '
+             'PIPENV = read from Pipfile.lock; '
+             'POETRY = read from a poetry.lock. '
+             '(Default = ENV)',
+        metavar='TYPE',
+        choices={'CONDA', 'CONDA_JSON', 'ENV', 'PIP', 'PIPENV', 'POETRY'},
+        default='ENV',
+        dest='sbom_input_type'
+    )

--- a/jake/command/parser_selector.py
+++ b/jake/command/parser_selector.py
@@ -57,8 +57,8 @@ def get_parser(input_type: str, input_data_fh: Optional[TextIO]) -> BaseParser:
 
 def add_parser_selector_arguments(arg_parser: ArgumentParser) -> None:
     arg_parser.add_argument(
-        '-i',
-        '--input',
+        '-f',
+        '--input-file',
         action='store',
         metavar='FILE_PATH',
         type=FileType('r'),

--- a/jake/command/parser_selector.py
+++ b/jake/command/parser_selector.py
@@ -71,6 +71,7 @@ def add_parser_selector_arguments(arg_parser: ArgumentParser) -> None:
         required=False
     )
     arg_parser.add_argument(
+        '-t',
         '-it',
         '--type',
         '--input-type',


### PR DESCRIPTION
This pull request makes the following changes:

- refactor `SbomCommand._get_parser()` method into a function in its own `parser_selector` module
- move the two needed argparse arguments to `add_parser_selector_arguments` function in the same module
- use those function in both `ddt` and `iq` commands.

BREAKING CHANGE: changed iq -i switch to -a, removed sbom -t switch (only -it works)

It relates to the following issue #s:
* Closes #104

cc @bhamail / @DarthHater
