### PR TITLE
Fix cython_sources build error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ requests = "^2.31.0"
 rich = "^10.10.0"
 
 [tool.poetry.dev-dependencies]
-tox = "^4.6.4"
+tox = "^3.28.0"
 coverage = "^6.2"
 flake8 = "^4.0.1"
 mypy = ">= 0.920, < 1.00"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ requests = "^2.31.0"
 rich = "^10.10.0"
 
 [tool.poetry.dev-dependencies]
-tox = "^3.24.3"
+tox = "^4.6.4"
 coverage = "^6.2"
 flake8 = "^4.0.1"
 mypy = ">= 0.920, < 1.00"

--- a/requirements.lowest.txt
+++ b/requirements.lowest.txt
@@ -16,7 +16,7 @@
 # This file records then lowest supported versions for dependencies.
 cyclonedx-bom == 3.0.0rc3
 importlib-metadata == 3.7.0 # ; python_version < '3.8'
-ossindex-lib == 1.0.0
+ossindex-lib == 1.1.1
 polling2 == 0.5.0
 pyfiglet == 0.7.6
 requests == 2.31.0


### PR DESCRIPTION
upgrade lowest to ossindex-lib 1.1.1, which appears to allow newer PyYAML (6+), which fixes cython_sources error when building PyYAML 5.4.1