### PR TITLE
semantic-release versioning configuration - for pypyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,8 +77,8 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.semantic_release]
-version_variable = [
-    "pyproject.toml:version"
+version_toml = [
+    "pyproject.toml:tool.poetry.version",
 ]
 branch = "main"
 upload_to_pypi = true


### PR DESCRIPTION
#148 
> I'm still not certain semantic-release is incrementing the version in pyproject.toml (which I thought it used to do).

This should do it per the python-semantic-release docs.  https://python-semantic-release.readthedocs.io/en/latest/configuration.html

It relates to the following issue #s:
* #147 #148 

cc @bhamail / @DarthHater
